### PR TITLE
Make build work on OS X

### DIFF
--- a/third_party/phantomjs/BUILD
+++ b/third_party/phantomjs/BUILD
@@ -11,7 +11,7 @@ genrule(
     cmd = " && ".join([
         "IN=$$(pwd)/$(SRCS)",
         "OUT=$$(pwd)/$@",
-        "TMP=$$(mktemp -d)",
+        "TMP=$$(mktemp -d tmp.XXXXXXXXXX)",
         "cd $$TMP",
         "tar -xjf $$IN",
         "cd phantomjs-*",


### PR DESCRIPTION
mktemp takes different arguments on OS (the template is required).

See http://ci.bazel.io/job/rules_closure/BAZEL_VERSION=HEAD,PLATFORM_NAME=darwin-x86_64/1/console.