### PR TITLE
Mention AngularJS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,11 @@ This rule must be used in conjunction with `closure_js_library`.
   flags are available, run:
   `bazel run @io_bazel_rules_closure//closure/compiler -- --help`
 
+### Support for AngularJS
+
+When compiling AngularJS applications these flags should be used for
+compatibility:
+- `defs=["--angular_pass", "--export_local_property_definitions"]`
 
 ## closure\_js\_test
 


### PR DESCRIPTION
This change set introduces new flags to the closure_js_binary
rule that help with angular integration:

 * --angular_pass
     allows processing of @ngInject for dependency injection

 * --export_local_property_definitions
     allows referencing controller properties from angular views

More details on the recommended patterns for integrating the
closure compiler with angular can be found here:

https://google.github.io/styleguide/angularjs-google-style.html