### PR TITLE
Phantomjs path fix

### DIFF
--- a/closure/testing/closure_js_test.bzl
+++ b/closure/testing/closure_js_test.bzl
@@ -79,8 +79,7 @@ def _impl(ctx):
       output=ctx.outputs.executable,
       content="\n".join([
           "#!/bin/sh",
-          "exec external/io_bazel_rules_closure/" + \
-          "third_party/phantomjs/phantomjs.sh \\",
+          "exec %s \\" % ctx.attr._phantomjs,
           "  %s \\" % ctx.file._phantomjs_runner.short_path,
           "  %s" % ctx.outputs.js.short_path,
           "",

--- a/closure/testing/closure_js_test.bzl
+++ b/closure/testing/closure_js_test.bzl
@@ -79,7 +79,8 @@ def _impl(ctx):
       output=ctx.outputs.executable,
       content="\n".join([
           "#!/bin/sh",
-          "exec third_party/phantomjs/phantomjs.sh \\",
+          "exec external/io_bazel_rules_closure/" + \
+          "third_party/phantomjs/phantomjs.sh \\",
           "  %s \\" % ctx.file._phantomjs_runner.short_path,
           "  %s" % ctx.outputs.js.short_path,
           "",

--- a/third_party/phantomjs/phantomjs.sh
+++ b/third_party/phantomjs/phantomjs.sh
@@ -35,7 +35,7 @@ export FONTCONFIG_PATH="${RUNFILES}/third_party/fontconfig"
 export XDG_DATA_HOME="${RUNFILES}"
 export XDG_CACHE_HOME="$(mktemp -d "${TMPDIR:-/tmp}/fontcache.XXXXXXXXXX")"
 
-"${RUNFILES}/third_party/phantomjs/bin/phantomjs" "$@"
+"${RUNFILES}/external/io_bazel_rules_closure/third_party/phantomjs/bin/phantomjs" "$@"
 rc="$?"
 rm -rf "${XDG_CACHE_HOME}"
 exit "${rc}"

--- a/third_party/phantomjs/phantomjs.sh
+++ b/third_party/phantomjs/phantomjs.sh
@@ -35,7 +35,7 @@ export FONTCONFIG_PATH="${RUNFILES}/third_party/fontconfig"
 export XDG_DATA_HOME="${RUNFILES}"
 export XDG_CACHE_HOME="$(mktemp -d "${TMPDIR:-/tmp}/fontcache.XXXXXXXXXX")"
 
-"${RUNFILES}/external/io_bazel_rules_closure/third_party/phantomjs/bin/phantomjs" "$@"
+"`basename $0`/bin/phantomjs" "$@"
 rc="$?"
 rm -rf "${XDG_CACHE_HOME}"
 exit "${rc}"


### PR DESCRIPTION
phantomjs and phantomjs.sh needed to have `external/io_bazel_rules_closure` prepended to their paths.
This resolves https://github.com/bazelbuild/rules_closure/issues/19