### PR TITLE
Mirror external files using Google Cloud Storage

### DIFF
--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -62,7 +62,7 @@ def closure_repositories():
 
   native.new_http_archive(
       name = "closure_library",
-      url = "https://github.com/google/closure-library/archive/20160208.zip",
+      url = "https://bazel-mirror.storage.googleapis.com/github.com/google/closure-library/archive/20160208.zip",
       sha256 = "8f610300e4930190137505a574a54d12346426f2a7b4f179026e41674e452a86",
       strip_prefix = "closure-library-20160208",
       build_file = "closure/library/closure_library.BUILD",
@@ -70,7 +70,7 @@ def closure_repositories():
 
   native.new_http_archive(
       name = "closure_linter",
-      url = "https://github.com/google/closure-linter/archive/v2.3.19.zip",
+      url = "https://bazel-mirror.storage.googleapis.com/github.com/google/closure-linter/archive/v2.3.19.zip",
       sha256 = "ccb93b7327cd1e1520d0090c51f2f11d5174a34df24e1fa4d0114ffff28a7141",
       strip_prefix = "closure-linter-2.3.19",
       build_file = "closure/linter/closure_linter.BUILD",
@@ -84,13 +84,13 @@ def closure_repositories():
 
   native.http_file(
       name = "fonts_noto_hinted_deb",
-      url = "http://http.us.debian.org/debian/pool/main/f/fonts-noto/fonts-noto-hinted_20160116-1_all.deb",
+      url = "https://bazel-mirror.storage.googleapis.com/http.us.debian.org/debian/pool/main/f/fonts-noto/fonts-noto-hinted_20160116-1_all.deb",
       sha256 = "25b362c9437a7859ce034f22d94b698e8ed25007b443e5a26228ed5b3d2d32d4",
   )
 
   native.http_file(
       name = "fonts_noto_mono_deb",
-      url = "http://http.us.debian.org/debian/pool/main/f/fonts-noto/fonts-noto-mono_20160116-1_all.deb",
+      url = "https://bazel-mirror.storage.googleapis.com/http.us.debian.org/debian/pool/main/f/fonts-noto/fonts-noto-mono_20160116-1_all.deb",
       sha256 = "74b457715f275ed893998a70d6bc955f67da6d36b36b422dbeeb045160edacb6",
   )
 
@@ -120,43 +120,43 @@ def closure_repositories():
 
   native.http_file(
       name = "libexpat_amd64_deb",
-      url = "http://http.us.debian.org/debian/pool/main/e/expat/libexpat1_2.1.0-6+deb8u1_amd64.deb",
+      url = "https://bazel-mirror.storage.googleapis.com/http.us.debian.org/debian/pool/main/e/expat/libexpat1_2.1.0-6+deb8u1_amd64.deb",
       sha256 = "1b006e659f383e09909595d8b84b79828debd7323d00e8a28b72ccd902273861",
   )
 
   native.http_file(
       name = "libfontconfig_amd64_deb",
-      url = "http://http.us.debian.org/debian/pool/main/f/fontconfig/libfontconfig1_2.11.0-6.3_amd64.deb",
+      url = "https://bazel-mirror.storage.googleapis.com/http.us.debian.org/debian/pool/main/f/fontconfig/libfontconfig1_2.11.0-6.3_amd64.deb",
       sha256 = "2b21f91c8b46caba41221f1e45c5a37cac08ce1298dd7a28442f1b7332fa211b",
   )
 
   native.http_file(
       name = "libfreetype_amd64_deb",
-      url = "http://http.us.debian.org/debian/pool/main/f/freetype/libfreetype6_2.5.2-3+deb8u1_amd64.deb",
+      url = "https://bazel-mirror.storage.googleapis.com/http.us.debian.org/debian/pool/main/f/freetype/libfreetype6_2.5.2-3+deb8u1_amd64.deb",
       sha256 = "80184d932f9b0acc130af081c60a2da114c7b1e7531c18c63174498fae47d862",
   )
 
   native.http_file(
       name = "libpng_amd64_deb",
-      url = "http://http.us.debian.org/debian/pool/main/libp/libpng/libpng12-0_1.2.50-2+deb8u2_amd64.deb",
+      url = "https://bazel-mirror.storage.googleapis.com/http.us.debian.org/debian/pool/main/libp/libpng/libpng12-0_1.2.50-2+deb8u2_amd64.deb",
       sha256 = "a57b6d53169c67a7754719f4b742c96554a18f931ca5b9e0408fb6502bb77e80",
   )
 
   native.http_file(
       name = "phantomjs_linux_x86_64",
       sha256 = "86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f",
-      url = "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2",
+      url = "https://bazel-mirror.storage.googleapis.com/bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2",
   )
 
   native.http_file(
       name = "phantomjs_macosx",
       sha256 = "538cf488219ab27e309eafc629e2bcee9976990fe90b1ec334f541779150f8c1",
-      url = "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-macosx.zip",
+      url = "https://bazel-mirror.storage.googleapis.com/bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-macosx.zip",
   )
 
   native.new_http_archive(
       name = "python_gflags",
-      url = "https://github.com/google/python-gflags/archive/3.0.2.zip",
+      url = "https://bazel-mirror.storage.googleapis.com/github.com/google/python-gflags/archive/3.0.2.zip",
       sha256 = "8700f5b8d61f843425b090287874b4ff45510d858caa109847162dd98c7856f8",
       strip_prefix = "python-gflags-3.0.2",
       build_file = "closure/linter/python_gflags.BUILD",
@@ -171,5 +171,5 @@ def closure_repositories():
   native.http_file(
       name = "soyutils_usegoog",
       sha256 = "fdb0e318949c1af668038df1d85d45353a00ff585f321c86efe91ac2a10cc91f",
-      url = "https://repo1.maven.org/maven2/com/google/template/soy/2016-01-12/soy-2016-01-12-soyutils_usegoog.js",
+      url = "https://bazel-mirror.storage.googleapis.com/repo1.maven.org/maven2/com/google/template/soy/2016-01-12/soy-2016-01-12-soyutils_usegoog.js",
   )


### PR DESCRIPTION
We've been experiencing a lot of build flakiness and failed installs due
to BitBucket's Amazon S3 hosting returning a lot of "AccessDenied:
Request has expired" errors.

We're now mirroring as much as possible to a GCS bucket run by the Bazel
team. This should be much faster and more reliable, since it introduces
fewer points of failure. That means happy Closure Rules users. It also
eliminates the possibility that any system administrators will be crying
over the fact that our CI systems are hammering their servers for
dependencies.

Reviewer: @wolfgangmeyers 