### PR TITLE
Fix closure_js_deps and test it

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ admin-only path named `/filez/`, then raw source mode could be used as follows:
 
 ```html
 <script src="/filez/external/closure_library/closure/goog/base.js"></script>
-<script src="/filez/myapp/deps-runfiles.js"></script>
+<script src="/filez/myapp/deps.js"></script>
 <script>goog.require('myapp.main');</script>
 <script>myapp.main();</script>
 ```
@@ -427,12 +427,7 @@ admin-only path named `/filez/`, then raw source mode could be used as follows:
 - *name*.js: A JavaScript source file containing `goog.addDependency()`
   statements which map Closure Library namespaces to JavaScript source paths.
   Each path is expressed relative to the location of the Closure Library
-  `base.js` file. The paths in this file will contain direct references to the
-  files in Bazel's output directories.
-
-- *name*-runfiles.js: This file is the same as *name*.js except its paths will
-  not contain any of the weird Bazel output directories. This is the file that
-  you want to use when loading sources from a web server.
+  `base.js` file.
 
 ### Arguments
 

--- a/closure/compiler/closure_js_deps.bzl
+++ b/closure/compiler/closure_js_deps.bzl
@@ -14,31 +14,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Build definitions for JavaScript dependency files.
-
-Generating this file is important because the deps-runfiles.js file tells the
-Closure Library how to send requests to the web server to load goog.require'd
-namespaces.
-"""
-
-load("//closure/private:defs.bzl",
-     "JS_FILE_TYPE",
-     "make_js_deps_runfiles")
+"""Build definitions for JavaScript dependency files."""
 
 def _impl(ctx):
+  # XXX: Other files in same directory will get schlepped in w/o sandboxing.
+  basejs = list(ctx.attr._library_base.transitive_js_srcs)[0]
+  closure_root = _dirname(basejs.short_path)
+  closure_rel = '/'.join(['..' for _ in range(len(closure_root.split('/')))])
   srcs = set(order="compile")
   for src in ctx.attr.deps:
     srcs += src.transitive_js_srcs
   ctx.action(
       inputs=list(srcs),
       outputs=[ctx.outputs.out],
-      arguments=(["--output_file=%s" % (ctx.outputs.out.path)] +
-                 [src.path for src in srcs]),
+      arguments=(["--output_file=%s" % ctx.outputs.out.path] +
+                 ["--root_with_prefix=%s %s" % (
+                     r, _make_prefix(p, closure_root, closure_rel))
+                  for r, p in _find_roots(
+                      [(src.dirname, src.short_path) for src in srcs])]),
       executable=ctx.executable._depswriter,
       progress_message="Calculating %d JavaScript deps to %s" % (
           len(srcs), ctx.outputs.out.short_path))
-  make_js_deps_runfiles(ctx, srcs)
-  return struct(files=set([ctx.outputs.out, ctx.outputs.runfiles]))
+  return struct(files=set([ctx.outputs.out]))
+
+def _dirname(path):
+  return path[:path.rindex('/')]
+
+def _find_roots(dirs):
+  roots = {}
+  for _, d, p in sorted([(len(d.split("/")), d, p) for d, p in dirs]):
+    parts = d.split("/")
+    want = True
+    for i in range(len(parts)):
+      if "/".join(parts[:i + 1]) in roots:
+        want = False
+        break
+    if want:
+      roots[d] = p
+  return roots.items()
+
+def _make_prefix(prefix, closure_root, closure_rel):
+  prefix = "/".join(prefix.split("/")[:-1])
+  if not prefix:
+    return closure_rel
+  elif prefix == closure_root:
+    return "."
+  elif prefix.startswith(closure_root + "/"):
+    return prefix[len(closure_root) + 1:]
+  else:
+    return closure_rel + "/" + prefix
 
 closure_js_deps = rule(
     implementation=_impl,
@@ -49,6 +73,7 @@ closure_js_deps = rule(
         "_depswriter": attr.label(
             default=Label("@closure_library//:depswriter"),
             executable=True),
+        "_library_base": attr.label(
+            default=Label("//closure/library:base")),
     },
-    outputs={"out": "%{name}.js",
-             "runfiles": "%{name}-runfiles.js"})
+    outputs={"out": "%{name}.js"})

--- a/closure/compiler/test/BUILD
+++ b/closure/compiler/test/BUILD
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 load("//closure/compiler:closure_js_binary.bzl", "closure_js_binary")
-load("//closure/compiler:closure_js_deps.bzl", "closure_js_deps")
 load("//closure/compiler:closure_js_library.bzl", "closure_js_library")
 load("//closure/private:test_rules.bzl", "file_test")
 

--- a/closure/compiler/test/closure_js_deps/BUILD
+++ b/closure/compiler/test/closure_js_deps/BUILD
@@ -1,0 +1,56 @@
+# Copyright 2016 The Closure Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//closure/compiler:closure_js_deps.bzl", "closure_js_deps")
+load("//closure/compiler:closure_js_library.bzl", "closure_js_library")
+load("//closure/private:test_rules.bzl", "file_test")
+
+closure_js_library(
+    name = "hyperion",
+    srcs = ["hyperion.js"],
+)
+
+closure_js_deps(
+    name = "hyperion_deps",
+    deps = [":hyperion"],
+)
+
+file_test(
+    name = "noTransitiveDeps_containsSingleLineRelativeToClosureLibraryBaseJs",
+    file = "hyperion_deps.js",
+    regexp = "^goog.addDependency('../../../../closure/compiler/test/closure_js_deps/hyperion.js', \\['hyperion'\\], \\[\\], false);$",
+)
+
+closure_js_library(
+    name = "goblin",
+    srcs = ["goblin.js"],
+    deps = ["//closure/library"],
+)
+
+closure_js_deps(
+    name = "goblin_deps",
+    deps = [":goblin"],
+)
+
+file_test(
+    name = "module_usesTrueArgument",
+    file = "goblin_deps.js",
+    regexp = "^goog.addDependency('../../../../closure/compiler/test/closure_js_deps/goblin.js', \\['goblin'\\], \\['goog.dom'\\], true);$",
+)
+
+file_test(
+    name = "googDomDependency_includesClosureLibraryStuffInDepsFile",
+    file = "goblin_deps.js",
+    regexp = "^goog.addDependency('\\./dom/dom\\.js', \\['goog\\.dom'",
+)

--- a/closure/compiler/test/closure_js_deps/goblin.js
+++ b/closure/compiler/test/closure_js_deps/goblin.js
@@ -1,0 +1,59 @@
+// Copyright 2016 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+goog.module('goblin');
+
+var dom = goog.require('goog.dom');
+
+
+/**
+ * Morning and evening
+ * Maids heard the goblins cry:
+ * “Come buy our orchard fruits,
+ * Come buy, come buy:
+ * Apples and quinces,
+ * Lemons and oranges,
+ * Plump unpeck’d cherries,
+ * Melons and raspberries,
+ * Bloom-down-cheek’d peaches,
+ * Swart-headed mulberries,
+ * Wild free-born cranberries,
+ * Crab-apples, dewberries,
+ * Pine-apples, blackberries,
+ * Apricots, strawberries;—
+ * All ripe together
+ * In summer weather,—
+ * Morns that pass by,
+ * Fair eves that fly;
+ * Come buy, come buy:
+ * Our grapes fresh from the vine,
+ * Pomegranates full and fine,
+ * Dates and sharp bullaces,
+ * Rare pears and greengages,
+ * Damsons and bilberries,
+ * Taste them and try:
+ * Currants and gooseberries,
+ * Bright-fire-like barberries,
+ * Figs to fill your mouth,
+ * Citrons from the South,
+ * Sweet to tongue and sound to eye;
+ * Come buy, come buy.”
+ */
+function goblin() {
+  dom.getElement('goblin');
+  console.log('Goblin Market by Christina Rossetti');
+}
+
+
+exports = goblin;

--- a/closure/compiler/test/closure_js_deps/hyperion.js
+++ b/closure/compiler/test/closure_js_deps/hyperion.js
@@ -1,0 +1,42 @@
+// Copyright 2016 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+goog.provide('hyperion');
+
+
+/**
+ * CANTO I
+ *
+ * Fanatics have their dreams, wherewith they weave
+ * A paradise for a sect; the savage too
+ * From forth the loftiest fashion of his sleep
+ * Guesses at Heaven; pity these have not
+ * Trac'd upon vellum or wild Indian leaf
+ * The shadows of melodious utterance.
+ * But bare of laurel they live, dream, and die;
+ * For Poesy alone can tell her dreams,
+ * With the fine spell of words alone can save
+ * Imagination from the sable charm
+ * And dumb enchantment. Who alive can say,
+ * 'Thou art no Poet may'st not tell thy dreams?'
+ * Since every man whose soul is not a clod
+ * Hath visions, and would speak, if he had loved
+ * And been well nurtured in his mother tongue.
+ * Whether the dream now purpos'd to rehearse
+ * Be poet's or fanatic's will be known
+ * When this warm scribe my hand is in the grave.
+ */
+function hyperion() {
+  console.log('The Fall of Hyperion - A Dream by John Keats');
+}


### PR DESCRIPTION
- Make `closure_js_deps` actually work.

- Breaking API change: We no longer generate the legacy deps.js file that includes the weird bazel directory names. We only generate the deps-runfiles.js file now.

- Regression tests.