### PR TITLE
Put Closure Library base.js in deps by default

### DIFF
--- a/closure/compiler/closure_js_deps.bzl
+++ b/closure/compiler/closure_js_deps.bzl
@@ -16,9 +16,11 @@
 
 """Build definitions for JavaScript dependency files."""
 
+load("//closure/private:defs.bzl", "CLOSURE_LIBRARY_BASE_ATTR")
+
 def _impl(ctx):
   # XXX: Other files in same directory will get schlepped in w/o sandboxing.
-  basejs = list(ctx.attr._library_base.transitive_js_srcs)[0]
+  basejs = ctx.file._closure_library_base
   closure_root = _dirname(basejs.short_path)
   closure_rel = '/'.join(['..' for _ in range(len(closure_root.split('/')))])
   srcs = set(order="compile")
@@ -70,10 +72,9 @@ closure_js_deps = rule(
         "deps": attr.label_list(
             allow_files=False,
             providers=["transitive_js_srcs"]),
+        "_closure_library_base": CLOSURE_LIBRARY_BASE_ATTR,
         "_depswriter": attr.label(
             default=Label("@closure_library//:depswriter"),
             executable=True),
-        "_library_base": attr.label(
-            default=Label("//closure/library:base")),
     },
     outputs={"out": "%{name}.js"})

--- a/closure/compiler/closure_js_library.bzl
+++ b/closure/compiler/closure_js_library.bzl
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Build definitions for Closure JavaScript libraries.
-"""
+"""Build definitions for Closure JavaScript libraries."""
 
 load("//closure/private:defs.bzl",
+     "CLOSURE_LIBRARY_BASE_ATTR",
      "JS_LANGUAGE_DEFAULT",
      "JS_DEPS_ATTR",
      "JS_FILE_TYPE",
@@ -90,12 +90,14 @@ closure_js_library = rule(
         "language": attr.string(default=JS_LANGUAGE_DEFAULT),
         "convention": attr.string(default="CLOSURE"),
         "suppress": attr.string_list(),
+        "no_closure_library": attr.bool(default=False),
 
         # internal only
         "internal_nofail": attr.bool(default=False),
         "_jschecker": attr.label(
             default=Label("//java/com/google/javascript/jscomp:jschecker"),
             executable=True),
+        "_closure_library_base": CLOSURE_LIBRARY_BASE_ATTR,
     },
     outputs={
         "provided": "%{name}-provided.txt",

--- a/closure/compiler/test/BUILD
+++ b/closure/compiler/test/BUILD
@@ -94,6 +94,7 @@ closure_js_library(
     name = "es6const_lib",
     srcs = ["es6const.js"],
     language = "ECMASCRIPT6_STRICT",
+    no_closure_library = True,
 )
 
 closure_js_binary(
@@ -113,6 +114,7 @@ closure_js_library(
     name = "es6arrow_lib",
     srcs = ["es6arrow.js"],
     language = "ECMASCRIPT6_STRICT",
+    no_closure_library = True,
 )
 
 closure_js_binary(
@@ -132,6 +134,7 @@ closure_js_library(
     name = "es6typed_lib",
     srcs = ["es6typed.js"],
     language = "ECMASCRIPT6_TYPED",
+    no_closure_library = True,
 )
 
 closure_js_binary(

--- a/closure/library/BUILD
+++ b/closure/library/BUILD
@@ -29,7 +29,6 @@ closure_js_library(
         "JSC_MISSING_RETURN_JSDOC",
         "JSC_MUST_BE_PRIVATE",
     ],
-    deps = [":base"],
 )
 
 closure_js_library(
@@ -48,17 +47,4 @@ closure_js_library(
 closure_css_library(
     name = "css",
     srcs = ["@closure_library//:css_files"],
-)
-
-# This file doesn't goog.provide() any namespaces, so it won't break strict
-# dependency checking if you only link against :library, which is recommended
-# for Closure Library users. This target exists so it can be added as a
-# lightweight dependency when source code uses things like ES6 modules. This is
-# because the Closure Compiler generates synthetic code with goog.provide()
-# statements.
-closure_js_library(
-    name = "base",
-    srcs = ["@closure_library//:closure/goog/base.js"],
-    language = "ECMASCRIPT5_STRICT",
-    suppress = ["JSC_INVALID_SUPPRESS"],
 )

--- a/closure/private/defs.bzl
+++ b/closure/private/defs.bzl
@@ -51,9 +51,19 @@ JS_DEPS_ATTR = attr.label_list(
                "transitive_js_srcs",
                "transitive_js_externs"])
 
+CLOSURE_LIBRARY_BASE_ATTR = attr.label(
+    default=Label("@closure_library//:closure/goog/base.js"),
+    allow_files=True,
+    single_file=True)
+
 def collect_js_srcs(ctx):
   srcs = set(order="compile")
   externs = set(order="compile")
+  base = None
+  if (hasattr(ctx.file, '_closure_library_base')
+      and (not hasattr(ctx.attr, 'no_closure_library')
+           or not ctx.attr.no_closure_library)):
+    srcs += [ctx.file._closure_library_base]
   for dep in ctx.attr.deps:
     srcs += dep.transitive_js_srcs
     externs += dep.transitive_js_externs

--- a/closure/testing/closure_js_test.bzl
+++ b/closure/testing/closure_js_test.bzl
@@ -23,6 +23,7 @@
 #      https://github.com/ariya/phantomjs/issues/14028
 
 load("//closure/private:defs.bzl",
+     "CLOSURE_LIBRARY_BASE_ATTR",
      "JS_DEPS_ATTR",
      "JS_HIDE_WARNING_ARGS",
      "JS_LANGUAGE_DEFAULT",
@@ -102,6 +103,7 @@ _closure_js_test = rule(
         "deps": JS_DEPS_ATTR,
         "pedantic": attr.bool(default=False),
         "defs": attr.string_list(),
+        "_closure_library_base": CLOSURE_LIBRARY_BASE_ATTR,
         "_compiler": attr.label(
             default=Label("//closure/compiler"),
             executable=True),

--- a/closure/testing/test/BUILD
+++ b/closure/testing/test/BUILD
@@ -73,8 +73,6 @@ closure_js_library(
     name = "arithmetic_es6module_lib",
     srcs = ["arithmetic_es6module.js"],
     language = "ECMASCRIPT6_STRICT",
-    # ES6 modules cause synthetic code to be generated using goog.provide.
-    deps = ["//closure/library:base"],
 )
 
 closure_js_test(


### PR DESCRIPTION
Many Closure Compiler passes generate synthetic code that calls functions in [base.js](https://github.com/google/closure-library/blob/master/closure/goog/base.js). I don't want users to shoot themselves in the foot wondering why their ES6 modules won't compile without a mysterious `//closure/library:base` dependency they aren't actually using. It's better off being linked by default.

In fact, we're going to remove the `//closure/library:base` rule entirely, since strict dependency checking can't be applied to it. This is because it's logically impossible to say `goog.require('goog')`.

The only downside to using this library by default is that binaries will be bloated with its contents when compiled in `debug = True` or `compilation_level = "WHITESPACE_ONLY"` mode.

Therefore, a `no_closure_library` flag has been added to `closure_js_library` to opt-out of this behavior.