### PR TITLE
Change closure_js_binary() main to entry_points

### DIFF
--- a/closure/compiler/closure_js_deps.bzl
+++ b/closure/compiler/closure_js_deps.bzl
@@ -20,6 +20,8 @@ load("//closure/private:defs.bzl", "CLOSURE_LIBRARY_BASE_ATTR")
 
 def _impl(ctx):
   # XXX: Other files in same directory will get schlepped in w/o sandboxing.
+  if not ctx.attr.deps:
+    fail("closure_js_deps rules can not have an empty 'deps' list")
   basejs = ctx.file._closure_library_base
   closure_root = _dirname(basejs.short_path)
   closure_rel = '/'.join(['..' for _ in range(len(closure_root.split('/')))])

--- a/closure/compiler/closure_js_library.bzl
+++ b/closure/compiler/closure_js_library.bzl
@@ -83,14 +83,14 @@ def _impl(ctx):
 closure_js_library = rule(
     implementation=_impl,
     attrs={
-        "srcs": attr.label_list(allow_files=JS_FILE_TYPE),
-        "externs": attr.label_list(allow_files=JS_FILE_TYPE),
+        "convention": attr.string(default="CLOSURE"),
         "deps": JS_DEPS_ATTR,
         "exports": JS_DEPS_ATTR,
+        "externs": attr.label_list(allow_files=JS_FILE_TYPE),
         "language": attr.string(default=JS_LANGUAGE_DEFAULT),
-        "convention": attr.string(default="CLOSURE"),
-        "suppress": attr.string_list(),
         "no_closure_library": attr.bool(default=False),
+        "srcs": attr.label_list(allow_files=JS_FILE_TYPE),
+        "suppress": attr.string_list(),
 
         # internal only
         "internal_nofail": attr.bool(default=False),

--- a/closure/compiler/test/BUILD
+++ b/closure/compiler/test/BUILD
@@ -63,6 +63,13 @@ file_test(
 )
 
 closure_js_library(
+    name = "empty_lib",
+    srcs = ["empty.js"],
+    language = "ECMASCRIPT6_STRICT",
+    visibility = ["//closure/compiler/test/exports_and_entry_points:__pkg__"],
+)
+
+closure_js_library(
     name = "unstrict_lib",
     srcs = ["empty.js"],
     language = "ECMASCRIPT3",

--- a/closure/compiler/test/exports_and_entry_points/BUILD
+++ b/closure/compiler/test/exports_and_entry_points/BUILD
@@ -1,0 +1,136 @@
+# Copyright 2016 The Closure Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_testonly = True)
+
+load("//closure/compiler:closure_js_binary.bzl", "closure_js_binary")
+load("//closure/compiler:closure_js_library.bzl", "closure_js_library")
+load("//closure/private:file_test.bzl", "file_test")
+
+################################################################################
+# Assume we want to write a JavaScript program (not a library) that we compile
+# into a JavaScript binary and run. In that case, we probably don't need
+# exports or entry points.
+#
+# closure_js_binary() compiles with dependency_mode="LOOSE" by default. So any
+# procedural statements (e.g. calling a function) in the global scope will be
+# included in the resulting binary, if and only if they exist in a file that
+# does not have a goog.provide() statement.
+
+closure_js_library(
+    name = "program_lib",
+    srcs = ["program.js"],
+)
+
+closure_js_binary(
+    name = "program_bin",
+    deps = [":program_lib"],
+)
+
+file_test(
+    name = "fileWithoutNamespacesExportsOrEntryPoints_producesBinaryThatExecutesCodeInGlobalNamespace",
+    content = "console.log(\"hi\");\n",
+    file = "program_bin.js",
+)
+
+################################################################################
+# Now assume we're writing a library. Our goal is to produce a binary that
+# exports functions we can call from a <script> tag in our HTML page:
+#
+#   <script src="library_bin.js"></script>
+#   <script>iWillGoIntoTheBinary();</script>
+#
+# In this case, we can use the @export annotation.
+
+closure_js_library(
+    name = "library_lib",
+    srcs = ["library.js"],
+)
+
+closure_js_binary(
+    name = "library_bin",
+    deps = [":library_lib"],
+)
+
+file_test(
+    name = "es6_exportedFunction_isOnlyThingInResultingBinary",
+    content = "function a(){console.log(\"hi\")}var b=[\"iWillGoIntoTheBinary\"],c=this;b[0]in c||!c.execScript||c.execScript(\"var \"+b[0]);for(var d;b.length&&(d=b.shift());)b.length||void 0===a?c[d]?c=c[d]:c=c[d]={}:c[d]=a;\n",
+    file = "library_bin.js",
+)
+
+################################################################################
+# Now assume our library uses Google style namespaces. Then @export alone isn't
+# sufficient.
+#
+# If a source file contains a single goog.provide() statement, then any
+# procedural statements in its global scope are considered dead code, unless
+# it's specified as an entry point.
+#
+# So we need both @export and entry_points.
+
+closure_js_library(
+    name = "library_goog_lib",
+    srcs = ["library_goog.js"],
+)
+
+closure_js_binary(
+    name = "library_goog_bin",
+    entry_points = ["goog:io.bazel.rules.closure.iWillGoIntoTheBinary"],
+    deps = [":library_goog_lib"],
+)
+
+file_test(
+    name = "goog_exportedFunction_isOnlyThingInResultingBinary",
+    # This looks more complicated than you'd expect, because it's actually
+    # compiling the synthetic goog.exportSymbol() call that @export generates.
+    content = "function a(){console.log(\"hi\")}var b=[\"io\",\"bazel\",\"rules\",\"closure\",\"iWillGoIntoTheBinary\"],c=this;b[0]in c||!c.execScript||c.execScript(\"var \"+b[0]);for(var d;b.length&&(d=b.shift());)b.length||void 0===a?c[d]?c=c[d]:c=c[d]={}:c[d]=a;\n",
+    file = "library_goog_bin.js",
+)
+
+################################################################################
+# If we use dependency_mode="STRICT" then we're forced to specify an
+# entry_point no matter what. But in order to specify an entry_point as a path,
+# we must make sure our language is set to ES6.
+
+closure_js_binary(
+    name = "program_strict_bin",
+    dependency_mode = "STRICT",
+    entry_points = ["closure/compiler/test/empty"],
+    deps = [
+        ":program_lib",
+        "//closure/compiler/test:empty_lib",
+    ],
+)
+
+file_test(
+    name = "strictModeGlobalCodeNotListedInEntryPoints_codeGoesPoof",
+    content = "\n",
+    file = "program_strict_bin.js",
+)
+
+closure_js_binary(
+    name = "program_strict_bin2",
+    dependency_mode = "STRICT",
+    entry_points = ["closure/compiler/test/exports_and_entry_points/program"],
+    deps = [
+        ":program_lib",
+        "//closure/compiler/test:empty_lib",
+    ],
+)
+
+file_test(
+    name = "strictModeGlobalCodeIsListedInEntryPoints_codeShowsUp",
+    content = "console.log(\"hi\");\n",
+    file = "program_strict_bin2.js",
+)

--- a/closure/compiler/test/exports_and_entry_points/library.js
+++ b/closure/compiler/test/exports_and_entry_points/library.js
@@ -1,0 +1,56 @@
+// Copyright 2016 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Example of how to use @export.
+
+
+/**
+ * Function that goes in binary, with name minimization, or possibly inlined
+ * entirely, because it's part of the call graph of an @export function in a
+ * module that is listed under entry_points in closure_js_binary().
+ */
+function myNameWillBeMinified() {
+  console.log('hi');
+}
+
+
+/**
+ * Function we want to be able to call from our HTML page.
+ *
+ * The Closure Compiler will see the @export JSDoc annotation below and
+ * generate the following synthetic code in the global scope:
+ *
+ *   goog.exportSymbol('iWillGoIntoTheBinary', iWillGoIntoTheBinary);
+ *
+ * That makes the minified version of this function still available in the
+ * global namespace. HOWEVER this function is still considered dead code,
+ * because nothing in this file actually calls it. So you still need to list
+ * this file under entry_points.
+ *
+ * You can also use @export for property names on classes, to prevent them
+ * from being minified.
+ *
+ * @export
+ */
+function iWillGoIntoTheBinary() {
+  myNameWillBeMinified();
+}
+
+
+/**
+ * See export.js for more information.
+ */
+function iWillGetPrunedByTheCompiler() {
+  console.log('no one loves me :(');
+}

--- a/closure/compiler/test/exports_and_entry_points/library_goog.js
+++ b/closure/compiler/test/exports_and_entry_points/library_goog.js
@@ -1,0 +1,66 @@
+// Copyright 2016 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Example of how to use @export with Google namespaces
+//
+// Unlike traditional JavaScript minifiers, the Closure Compiler will
+// aggressively minify names in the global namespace and prune dead code. Using
+// @export prevents this from happening.
+
+goog.provide('io.bazel.rules.closure.iWillGetPrunedByTheCompiler');
+goog.provide('io.bazel.rules.closure.iWillGoIntoTheBinary');
+goog.provide('io.bazel.rules.closure.myNameWillBeMinified');
+
+
+/**
+ * Function that goes in binary, with name minimization, or possibly inlined
+ * entirely, because it's part of the call graph of an @export function which
+ * is is listed under entry_points in closure_js_binary().
+ */
+io.bazel.rules.closure.myNameWillBeMinified = function() {
+  console.log('hi');
+};
+
+
+/**
+ * Function we want to be able to call from our HTML page.
+ *
+ * The Closure Compiler will see the @export JSDoc annotation below and
+ * generate the following synthetic code:
+ *
+ *   goog.exportSymbol('io.bazel.rules.closure.iWillGoIntoTheBinary',
+ *                     io.bazel.rules.closure.iWillGoIntoTheBinary);
+ *
+ * That makes the minified version of this function still available in the
+ * global namespace. HOWEVER this function is still considered dead code,
+ * because nothing in this file actually calls it. So you still need to list
+ * this file under entry_points.
+ *
+ * You can also use @export for property names on classes, to prevent them
+ * from being minified.
+ *
+ * @export
+ */
+io.bazel.rules.closure.iWillGoIntoTheBinary = function() {
+  io.bazel.rules.closure.myNameWillBeMinified();
+};
+
+
+/**
+ * Function that will be regarded as dead code, because it's not called by
+ * anything and isn't listed under entry_points in closure_js_binary().
+ */
+io.bazel.rules.closure.iWillGetPrunedByTheCompiler = function() {
+  console.log('no one loves me :(');
+};

--- a/closure/compiler/test/exports_and_entry_points/program.js
+++ b/closure/compiler/test/exports_and_entry_points/program.js
@@ -12,11 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-goog.setTestOnly();
+// Example of a self-contained program.
+//
+// closure_js_binary() can turn this file into a compiled JavaScript blob that
+// can be run. However the HTML page will not be able to call the functions that
+// are defined in this file, because they're not exported.
 
-import * as arithmetic from 'closure/testing/test/arithmetic_es6typed';
+
+/**
+ * Since this is not an @export function, the compiler will inline it into the
+ * invocation below.
+ */
+function iCantBeCalledExternally() {
+  console.log('hi');
+}
 
 
-function testAdd() {
-  assertEquals(4, arithmetic.add(2, 2));
+iCantBeCalledExternally();
+
+
+/**
+ * Since nothing calls this function, it's considered dead code and removed
+ * entirely.
+ */
+function iAmDeadCode() {
+  console.log('no one loves me');
 }

--- a/closure/library/closure_library.BUILD
+++ b/closure/library/closure_library.BUILD
@@ -824,7 +824,6 @@ filegroup(
         "third_party/closure/goog/loremipsum/text/loremipsum.js",
         "third_party/closure/goog/mochikit/async/deferred.js",
         "third_party/closure/goog/mochikit/async/deferredlist.js",
-        "third_party/closure/goog/osapi/osapi.js",
         "third_party/closure/goog/svgpan/svgpan.js",
     ],
 )
@@ -1005,6 +1004,7 @@ py_binary(
 #             "closure/goog/tweak/testhelpers.js",
 #             "closure/goog/useragent/useragenttestutil.js",
 #             "third_party/closure/goog/**/*_test.js",
+#             "third_party/closure/goog/osapi/osapi.js", # causes compiler errors
 #         ],
 #     ),
 #     outs = ["js_files_maker.txt"],

--- a/closure/private/defs.bzl
+++ b/closure/private/defs.bzl
@@ -78,8 +78,10 @@ def collect_js_srcs(ctx):
 
 def determine_js_language(ctx, normalize=False):
   language = "ANY"
-  if hasattr(ctx.attr, "language") and not hasattr(ctx.attr, "main"):
-    language = _check_js_language(ctx.attr.language)
+  if hasattr(ctx.attr, "language"):
+    # Don't do the language mixing check for closure_js_binary()
+    if not hasattr(ctx.attr, "entry_points"):
+      language = _check_js_language(ctx.attr.language)
   for dep in ctx.attr.deps:
     language = _mix_js_languages(ctx, language, dep.js_language)
   if hasattr(ctx.attr, "exports"):

--- a/closure/testing/closure_js_test.bzl
+++ b/closure/testing/closure_js_test.bzl
@@ -36,12 +36,12 @@ load("//closure/private:defs.bzl",
 # QtWebKit) supports ECMASCRIPT5_STRICT, we want to transpile to that language,
 # or whatever is nearest: http://kangax.github.io/compat-table/es5/#webkit
 _OUTPUT_LANGUAGE = {
-  "ECMASCRIPT3": "ECMASCRIPT3",
-  "ECMASCRIPT5": "ECMASCRIPT5",
-  "ECMASCRIPT6": "ECMASCRIPT5",
-  "ECMASCRIPT5_STRICT": "ECMASCRIPT5_STRICT",
-  "ECMASCRIPT6_STRICT": "ECMASCRIPT5_STRICT",
-  "ECMASCRIPT6_TYPED": "ECMASCRIPT5_STRICT",
+    "ECMASCRIPT3": "ECMASCRIPT3",
+    "ECMASCRIPT5": "ECMASCRIPT5",
+    "ECMASCRIPT6": "ECMASCRIPT5",
+    "ECMASCRIPT5_STRICT": "ECMASCRIPT5_STRICT",
+    "ECMASCRIPT6_STRICT": "ECMASCRIPT5_STRICT",
+    "ECMASCRIPT6_TYPED": "ECMASCRIPT5_STRICT",
 }
 
 def _impl(ctx):
@@ -126,7 +126,9 @@ _closure_js_test = rule(
 #      WHITESPACE_ONLY mode because other modes would be unreasonably slow.
 
 def closure_js_test(name, srcs, **kwargs):
-  if len(srcs) == 1:
+  if not srcs:
+    fail("closure_js_test rules can not have an empty 'srcs' list")
+  elif len(srcs) == 1:
     _closure_js_test(name = name, srcs = srcs, **kwargs)
   else:
     tests = []

--- a/closure/testing/test/arithmetic_es6typed.js
+++ b/closure/testing/test/arithmetic_es6typed.js
@@ -12,13 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-goog.provide('arithmetic');
-
-
 
 /**
  * Adds two numbers.
  */
-arithmetic.add = function(a: number, b: number): number {
+export function add(a: number, b: number): number {
   return a + b;
 };

--- a/closure/testing/test/arithmetic_scope_test.js
+++ b/closure/testing/test/arithmetic_scope_test.js
@@ -14,13 +14,12 @@
 
 goog.setTestOnly();
 
-goog.require('arithmetic');
-goog.require('goog.testing.testSuite');
+import * as arithmetic from 'closure/testing/test/arithmetic_es6typed';
+import 'goog:goog.testing.testSuite';
 
 goog.scope(function() {
-var testSuite = goog.testing.testSuite;
 
-testSuite({
+goog.testing.testSuite({
   testAdd: function() {
     assertEquals(4, arithmetic.add(2, 2));
   }


### PR DESCRIPTION
I got rid of the `main` attribute and introduced `entry_points` and `dependency_mode`. These will make the behavior more similar to the Closure Compiler, except with better error messages and documentation.

PTAL @robfig @hochhaus 