### PR TITLE
Add deps.js to forward-declare closure-library types

### DIFF
--- a/closure/compiler/closure_js_binary.bzl
+++ b/closure/compiler/closure_js_binary.bzl
@@ -19,6 +19,7 @@
 
 load("//closure/private:defs.bzl",
      "CLOSURE_LIBRARY_BASE_ATTR",
+     "CLOSURE_LIBRARY_DEPS_ATTR",
      "JS_DEPS_ATTR",
      "JS_LANGUAGE_DEFAULT",
      "JS_PEDANTIC_ARGS",
@@ -160,6 +161,7 @@ closure_js_binary = rule(
             default=Label("//closure/compiler"),
             executable=True),
         "_closure_library_base": CLOSURE_LIBRARY_BASE_ATTR,
+        "_closure_library_deps": CLOSURE_LIBRARY_DEPS_ATTR,
     },
     outputs={
         "out": "%{name}.js",

--- a/closure/compiler/closure_js_deps.bzl
+++ b/closure/compiler/closure_js_deps.bzl
@@ -16,7 +16,9 @@
 
 """Build definitions for JavaScript dependency files."""
 
-load("//closure/private:defs.bzl", "CLOSURE_LIBRARY_BASE_ATTR")
+load("//closure/private:defs.bzl",
+     "CLOSURE_LIBRARY_BASE_ATTR",
+     "CLOSURE_LIBRARY_DEPS_ATTR")
 
 def _impl(ctx):
   # XXX: Other files in same directory will get schlepped in w/o sandboxing.
@@ -75,6 +77,7 @@ closure_js_deps = rule(
             allow_files=False,
             providers=["transitive_js_srcs"]),
         "_closure_library_base": CLOSURE_LIBRARY_BASE_ATTR,
+        "_closure_library_deps": CLOSURE_LIBRARY_DEPS_ATTR,
         "_depswriter": attr.label(
             default=Label("@closure_library//:depswriter"),
             executable=True),

--- a/closure/compiler/closure_js_library.bzl
+++ b/closure/compiler/closure_js_library.bzl
@@ -18,6 +18,7 @@
 
 load("//closure/private:defs.bzl",
      "CLOSURE_LIBRARY_BASE_ATTR",
+     "CLOSURE_LIBRARY_DEPS_ATTR",
      "JS_LANGUAGE_DEFAULT",
      "JS_DEPS_ATTR",
      "JS_FILE_TYPE",
@@ -106,6 +107,7 @@ closure_js_library = rule(
             default=Label("//java/com/google/javascript/jscomp:jschecker"),
             executable=True),
         "_closure_library_base": CLOSURE_LIBRARY_BASE_ATTR,
+        "_closure_library_deps": CLOSURE_LIBRARY_DEPS_ATTR,
     },
     outputs={
         "provided": "%{name}-provided.txt",

--- a/closure/library/closure_library.BUILD
+++ b/closure/library/closure_library.BUILD
@@ -14,12 +14,13 @@
 
 package(default_visibility = ["//visibility:public"])
 
-exports_files(["closure/goog/base.js"])
+exports_files(["closure/goog/base.js", "closure/goog/deps.js"])
 
 filegroup(
     name = "js_files",
     srcs = [
         "closure/goog/base.js",
+        "closure/goog/deps.js",
         ":js_library_files",
         ":js_testing_files",
     ],

--- a/closure/private/defs.bzl
+++ b/closure/private/defs.bzl
@@ -64,6 +64,11 @@ CLOSURE_LIBRARY_BASE_ATTR = attr.label(
     allow_files=True,
     single_file=True)
 
+CLOSURE_LIBRARY_DEPS_ATTR = attr.label(
+    default=Label("@closure_library//:closure/goog/deps.js"),
+    allow_files=True,
+    single_file=True)
+
 def collect_js_srcs(ctx):
   srcs = set(order="compile")
   externs = set(order="compile")
@@ -71,11 +76,13 @@ def collect_js_srcs(ctx):
   if hasattr(ctx.attr, 'css'):
     if ctx.attr.css:
       srcs += [ctx.file._closure_library_base,
+               ctx.file._closure_library_deps,
                ctx.attr.css.js_css_renaming_map]
   elif (hasattr(ctx.file, '_closure_library_base')
       and (not hasattr(ctx.attr, 'no_closure_library')
            or not ctx.attr.no_closure_library)):
-    srcs += [ctx.file._closure_library_base]
+    srcs += [ctx.file._closure_library_base,
+             ctx.file._closure_library_deps]
   for dep in ctx.attr.deps:
     srcs += dep.transitive_js_srcs
     externs += dep.transitive_js_externs

--- a/closure/stylesheets/closure_css_binary.bzl
+++ b/closure/stylesheets/closure_css_binary.bzl
@@ -18,9 +18,7 @@
 """
 
 load("//closure/private:defs.bzl",
-     "CLOSURE_LIBRARY_BASE_ATTR",
      "CSS_DEPS_ATTR",
-     "JS_FILE_TYPE",
      "collect_transitive_css_labels")
 
 # XXX: Sourcemap functionality currently not supported because it's broken.

--- a/closure/testing/closure_js_test.bzl
+++ b/closure/testing/closure_js_test.bzl
@@ -24,6 +24,7 @@
 
 load("//closure/private:defs.bzl",
      "CLOSURE_LIBRARY_BASE_ATTR",
+     "CLOSURE_LIBRARY_DEPS_ATTR",
      "JS_DEPS_ATTR",
      "JS_HIDE_WARNING_ARGS",
      "JS_LANGUAGE_DEFAULT",
@@ -104,6 +105,7 @@ _closure_js_test = rule(
         "pedantic": attr.bool(default=False),
         "defs": attr.string_list(),
         "_closure_library_base": CLOSURE_LIBRARY_BASE_ATTR,
+        "_closure_library_deps": CLOSURE_LIBRARY_DEPS_ATTR,
         "_compiler": attr.label(
             default=Label("//closure/compiler"),
             executable=True),


### PR DESCRIPTION
https://github.com/google/closure-library/wiki/Frequently-Asked-Questions#when-i-compile-with-type-checking-on-i-get-warnings-about-bad-type-annotation-unknown-type-from-closure-library-files