### PR TITLE
Add Closure-style JavaScript protocol buffer utilities.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Closure Rules for Bazel (αlpha) [![Build Status](https://travis-ci.org/bazelbuild/rules_closure.svg?branch=master)](https://travis-ci.org/bazelbuild/rules_closure)
 
-JavaScript | Templating | Stylesheets
---- | --- | ---
-[closure_js_library](#closure_js_library) | [closure_template_js_library](#closure_template_js_library) | [closure_css_library](#closure_css_library)
-[closure_js_binary](#closure_js_binary) | [closure_template_java_library](#closure_template_java_library) | [closure_css_binary](#closure_css_binary)
-[closure_js_deps](#closure_js_deps) | [closure_template_py_library](#closure_template_py_library) |
-[closure_js_test](#closure_js_test) | |
+JavaScript | Templating | Stylesheets | Protocol Buffers
+--- | --- | --- | ---
+[closure_js_library](#closure_js_library) | [closure_template_js_library](#closure_template_js_library) | [closure_css_library](#closure_css_library) | [closure_proto_js_library](#closure_proto_js_library)
+[closure_js_binary](#closure_js_binary) | [closure_template_java_library](#closure_template_java_library) | [closure_css_binary](#closure_css_binary) |
+[closure_js_deps](#closure_js_deps) | [closure_template_py_library](#closure_template_py_library) | |
+[closure_js_test](#closure_js_test) | | |
 
 ## Overview
 
@@ -49,6 +49,9 @@ Closure Rules bundles the following tools and makes them "just work."
   unit tests in a command line environment.
 - [Bazel][bazel]: The build system Google uses to manage a repository with
   petabytes of code.
+- [Protocol Buffers][protobuf]: Google's language-neutral, platform-neutral,
+  extensible mechanism for serializing structured data. This is used instead of
+  untyped JSON.
 
 The Closure Tools were released to the public in 2009, but had previously been
 quite difficult to configure. They were originally designed to be used with
@@ -117,6 +120,7 @@ Please see the test directories within this project for concrete examples of usa
 - [//closure/library/test](https://github.com/bazelbuild/rules_closure/tree/master/closure/library/test)
 - [//closure/templates/test](https://github.com/bazelbuild/rules_closure/tree/master/closure/templates/test)
 - [//closure/stylesheets/test](https://github.com/bazelbuild/rules_closure/tree/master/closure/stylesheets/test)
+- [//protobuf/test](https://github.com/bazelbuild/rules_closure/tree/master/protobuf/test)
 
 
 # Reference
@@ -748,6 +752,47 @@ The documentation on using Closure Stylesheets can be found
   `bazel run @io_bazel_rules_closure//closure/stylesheets -- --help`
 
 
+## closure\_proto\_js\_library
+
+```python
+load("@io_bazel_rules_closure//closure:defs.bzl", "closure_proto_js_library")
+closure_proto_js_library(name, srcs, add_require_for_enums, binary,
+                         import_style)
+```
+
+Defines a set of Protocol Buffer files.
+
+Documentation: [Protocol Buffers][protobuf] [JS][protobuf-js]
+[Generator Options](https://github.com/google/protobuf/blob/master/src/google/protobuf/compiler/js/js_generator.h).
+
+#### Implicit Output Targets
+
+- *name*.js: A generated protocol buffer JavaScript library.
+
+### Arguments
+
+- **name:** ([Name][name]; required) A unique name for this rule. Convention
+  states that such rules be named `foo_proto`.
+
+- **srcs:** (List of [labels][labels]; required) A list of `.proto` source
+  files that represent this library.
+
+- **add_require_for_enums:** (Boolean; optional; default is `False`) Add a
+  `goog.require()` call for each enum type used. If false, a forward
+  declaration with `goog.forwardDeclare` is produced instead.
+
+- **binary:** (Boolean; optional; default is `True`) Enable binary-format
+  support.
+
+- **import_style:** (String; optional; default is `IMPORT_CLOSURE`) Specifies
+  the type of imports that should be used. Valid values are:
+
+  - `IMPORT_CLOSURE`    // goog.require()
+  - `IMPORT_COMMONJS`   // require()
+  - `IMPORT_BROWSER`    // no import statements
+  - `IMPORT_ES6`        // import { member } from ''
+
+
 
 [ClosureCodingConvention]: https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/ClosureCodingConvention.java
 [GoogleCodingConvention]: https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/GoogleCodingConvention.java
@@ -778,4 +823,6 @@ The documentation on using Closure Stylesheets can be found
 [managing-dependencies]: https://github.com/google/closure-compiler/wiki/Managing-Dependencies
 [phantomjs-bug]: https://github.com/ariya/phantomjs/issues/14028
 [phantomjs]: http://phantomjs.org/
+[protobuf]: https://github.com/google/protobuf
+[protobuf-js]: https://github.com/google/protobuf/tree/master/js
 [verbose]: https://github.com/google/closure-library/blob/master/closure/goog/html/safehtml.js

--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -197,6 +197,31 @@ def phantomjs_macosx():
       url = "https://bazel-mirror.storage.googleapis.com/bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-macosx.zip",
   )
 
+def protobuf_js():
+  native.new_http_archive(
+      name = "protobuf_js",
+      # TODO(hochhaus): Use protobuf-js-*.zip once it includes encoder.js.
+      # https://github.com/google/protobuf/pull/1589
+      url = "https://bazel-mirror.storage.googleapis.com/github.com/google/protobuf/archive/v3.0.0-beta-3.zip",
+      sha256 = "dad1912814e9d9b8642036d07c086ac79faf2cc534c992911375a39924a45860",
+      strip_prefix = "protobuf-3.0.0-beta-3",
+      build_file = str(Label("//protobuf:protobuf_js.BUILD")),
+  )
+
+def protoc_linux_x86_64():
+  native.http_file(
+      name = "protoc_linux_x86_64",
+      url = "https://bazel-mirror.storage.googleapis.com/github.com/google/protobuf/releases/download/v3.0.0-beta-3/protoc-3.0.0-beta-3-linux-x86_64.zip",
+      sha256 = "48c592c6272e2a5043de792ff00ff162fe6f9bebd60147b05888b08f8d0e434b",
+  )
+
+def protoc_macosx():
+  native.http_file(
+      name = "protoc_macosx",
+      url = "https://bazel-mirror.storage.googleapis.com/github.com/google/protobuf/releases/download/v3.0.0-beta-3/protoc-3.0.0-beta-3-osx-x86_64.zip",
+      sha256 = "b009b2b433affcf00dbe645d0637139f9a6c1e38c2c7d4cc99c30919f5c2eaac",
+  )
+
 def soy():
   native.maven_jar(
       name = "soy",
@@ -237,6 +262,9 @@ def closure_repositories(
     omit_libpng_amd64_deb=False,
     omit_phantomjs_linux_x86_64=False,
     omit_phantomjs_macosx=False,
+    omit_protobuf_js=False,
+    omit_protoc_linux_x86_64=False,
+    omit_protoc_macosx=False,
     omit_soy=False,
     omit_soyutils_usegoog=False):
   if not omit_aopalliance:
@@ -289,6 +317,12 @@ def closure_repositories(
     phantomjs_linux_x86_64()
   if not omit_phantomjs_macosx:
     phantomjs_macosx()
+  if not omit_protobuf_js:
+    protobuf_js()
+  if not omit_protoc_linux_x86_64:
+    protoc_linux_x86_64()
+  if not omit_protoc_macosx:
+    protoc_macosx()
   if not omit_soy:
     soy()
   if not omit_soyutils_usegoog:

--- a/protobuf/BUILD
+++ b/protobuf/BUILD
@@ -1,0 +1,27 @@
+# Copyright 2016 The Closure Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+load("//closure/compiler:closure_js_library.bzl", "closure_js_library")
+
+closure_js_library(
+    name = "jspb",
+    srcs = ["@protobuf_js//:proto_js_library_files"],
+    suppress = [
+        "JSC_EXTRA_REQUIRE_WARNING",
+        "JSC_OPTIONAL_PARAM_NOT_MARKED_OPTIONAL",
+    ],
+    deps = ["//closure/library"],
+)

--- a/protobuf/closure_proto_js_library.bzl
+++ b/protobuf/closure_proto_js_library.bzl
@@ -1,0 +1,62 @@
+# -*- mode: python; -*-
+#
+# Copyright 2016 The Closure Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utilities for building JavaScript Protocol Buffers.
+"""
+
+load("//closure/compiler:closure_js_library.bzl", "closure_js_library")
+
+def closure_proto_js_library(
+    name,
+    srcs,
+    visibility = None,
+    add_require_for_enums = 0,
+    testonly = 0,
+    binary = 1,
+    import_style = None,
+    protocbin = Label("//third_party/protobuf:protoc_bin")):
+  cmd = ["$(location %s)" % protocbin]
+  js_out_options = ["library=%s,error_on_name_conflict" % name]
+  if add_require_for_enums:
+    js_out_options += ["add_require_for_enums"]
+  if testonly:
+    js_out_options += ["testonly"]
+  if binary:
+    js_out_options += ["binary"]
+  if import_style:
+    js_out_options += ["import_style=%s" % import_style]
+  cmd += ["--js_out=%s:$(@D)" % ",".join(js_out_options)]
+  cmd += ["$(location " + src + ")" for src in srcs]
+
+  native.genrule(
+      name = name + "_gen",
+      srcs = srcs,
+      testonly = testonly,
+      visibility = visibility,
+      message = "Generating JavaScript Protocol Buffer file",
+      outs = [ name + ".js" ],
+      tools = [protocbin],
+      cmd = " ".join(cmd),
+  )
+
+  closure_js_library(
+      name = name,
+      srcs = [ name + ".js" ],
+      deps = [
+          str(Label("//closure/library")),
+          str(Label("//protobuf:jspb")),
+      ],
+  )

--- a/protobuf/protobuf_js.BUILD
+++ b/protobuf/protobuf_js.BUILD
@@ -1,0 +1,18 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # BSD
+
+filegroup(
+    name = "proto_js_library_files",
+    srcs = [
+        "js/debug.js",
+        "js/message.js",
+        "js/binary/arith.js",
+        "js/binary/constants.js",
+        "js/binary/decoder.js",
+        "js/binary/encoder.js",
+        "js/binary/reader.js",
+        "js/binary/utils.js",
+        "js/binary/writer.js",
+    ],
+)

--- a/protobuf/test/BUILD
+++ b/protobuf/test/BUILD
@@ -1,5 +1,3 @@
-# -*- mode: python; -*-
-#
 # Copyright 2016 The Closure Rules Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,13 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//closure/compiler:closure_js_binary.bzl", "closure_js_binary")
-load("//closure/compiler:closure_js_deps.bzl", "closure_js_deps")
+package(default_testonly = True)
+
 load("//closure/compiler:closure_js_library.bzl", "closure_js_library")
-load("//closure:repositories.bzl", "closure_repositories")
-load("//closure/stylesheets:closure_css_binary.bzl", "closure_css_binary")
-load("//closure/stylesheets:closure_css_library.bzl", "closure_css_library")
 load("//closure/testing:closure_js_test.bzl", "closure_js_test")
-load("//closure/templates:closure_template_java_library.bzl", "closure_template_java_library")
-load("//closure/templates:closure_template_js_library.bzl", "closure_template_js_library")
 load("//protobuf:closure_proto_js_library.bzl", "closure_proto_js_library")
+
+closure_proto_js_library(
+    name = "example_proto",
+    srcs = ["example.proto"],
+)
+
+closure_js_library(
+    name = "example_lib",
+    srcs = ["example.js"],
+    deps = [
+        ":example_proto",
+        "//closure/library",
+    ],
+)
+
+closure_js_test(
+    name = "example_test",
+    srcs = ["example_test.js"],
+    deps = [":example_lib"],
+)

--- a/protobuf/test/example.js
+++ b/protobuf/test/example.js
@@ -1,0 +1,45 @@
+// Copyright 2016 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+goog.provide('io.bazel.rules.closure.protobuf.Example');
+
+goog.require('proto.io.bazel.rules.closure.protobuf.Message');
+
+
+
+/**
+ * Example page.
+ * @param {string} field Value to set for "field".
+ * @constructor
+ * @final
+ */
+io.bazel.rules.closure.protobuf.Example = function(field) {
+
+  /**
+   * Message
+   * @private {!proto.io.bazel.rules.closure.protobuf.Message}
+   * @const
+   */
+  this.message_ = new proto.io.bazel.rules.closure.protobuf.Message();
+  this.message_.setFoo(field);
+};
+
+
+/**
+ * Return value of "field".
+ * @return {string}
+ */
+io.bazel.rules.closure.protobuf.Example.prototype.field = function() {
+  return this.message_.getFoo();
+};

--- a/protobuf/test/example.proto
+++ b/protobuf/test/example.proto
@@ -1,0 +1,21 @@
+// Copyright 2016 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package io.bazel.rules.closure.protobuf;
+
+message Message {
+  string foo = 1;
+}

--- a/protobuf/test/example_test.js
+++ b/protobuf/test/example_test.js
@@ -1,0 +1,22 @@
+// Copyright 2016 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+goog.require('io.bazel.rules.closure.protobuf.Example');
+
+
+function testExample() {
+  var msg = new io.bazel.rules.closure.protobuf.Example('value');
+  msg.field();
+  assertHTMLEquals('value', msg.field());
+}

--- a/third_party/protobuf/BUILD
+++ b/third_party/protobuf/BUILD
@@ -1,0 +1,28 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # BSD
+
+genrule(
+    name = "protoc_bin",
+    srcs = select({
+        ":darwin": ["@protoc_macosx//file"],
+        "//conditions:default": ["@protoc_linux_x86_64//file"],
+    }),
+    outs = ["protoc"],
+    cmd = " && ".join([
+        "IN=$$(pwd)/$(SRCS)",
+        "OUT=$$(pwd)/$@",
+        "TMP=$$(mktemp -d $${TMPDIR:-/tmp}/genrule.XXXXXXXXXX)",
+        "cd $$TMP",
+        "unzip -q $$IN protoc",
+        "mv protoc $$OUT",
+        "rm -rf $$TMP",
+    ]),
+    executable = True,
+)
+
+config_setting(
+    name = "darwin",
+    values = {"cpu": "darwin"},
+    visibility = ["//visibility:private"],
+)


### PR DESCRIPTION
Is adding (closure-style) protocol buffer support to this library something that you are willing to consider?

My reasons for thinking this rule fits well here are that the proto3 JS output can be tightly coupled with `closure_js_library()` making protocol buffers trivial to use from JavaScript. If a `js_proto_library()` rule were added to the upstream protobuf repository it would likely not be integrated as well into the rules_closure ecosystem.

If you prefer this as a separate project it is easy for me to split it to out.