### PR TITLE
Add common defines and output_wrapper to closure_js_binary()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Closure Rules for Bazel (αlpha) [![Build Status](https://travis-ci.org/bazelbuild/rules_closure.svg?branch=master)](https://travis-ci.org/bazelbuild/rules_closure)
 
 JavaScript | Templating | Stylesheets | Miscellaneous
---- | --- | --- | --- | ---
+--- | --- | --- | ---
 [closure_js_library](#closure_js_library) | [closure_template_js_library](#closure_template_js_library) | [closure_css_library](#closure_css_library) | [closure_proto_js_library](#closure_proto_js_library)
 [closure_js_binary](#closure_js_binary) | [closure_template_java_library](#closure_template_java_library) | [closure_css_binary](#closure_css_binary) | [phantomjs_test](#phantomjs_test)
 [closure_js_deps](#closure_js_deps) | [closure_template_py_library](#closure_template_py_library) | |
@@ -278,7 +278,8 @@ target. See the documentation of the `deps` attribute for further information.
 ```python
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_binary")
 closure_js_binary(name, deps, css, pedantic, debug, language, entry_points,
-                  dependency_mode, compilation_level, formatting, defs)
+                  dependency_mode, compilation_level, formatting,
+                  output_wrapper, defs)
 ```
 
 Turns JavaScript libraries into a minified optimized blob of code.
@@ -375,6 +376,13 @@ This rule must be used in conjunction with `closure_js_library`.
   - `PRETTY_PRINT`
   - `PRINT_INPUT_DELIMITER`
   - `SINGLE_QUOTES`
+
+- **output_wrapper:** (String; optional; default is
+  `"(function(){%output%}).call(this);"`) Wraps the compiled code. The
+  [default][output-wrapper-faq] specifies an anonymous function to prevent
+  variables from polluting the global scope. If you are using compiler level
+  modules you should disable this option with `output_wrapper=""` and pass
+  `module_wrapper` via `defs` instead.
 
 - **defs:** (List of strings; optional) Specifies additional flags to be passed
   to the Closure Compiler, e.g. `"--hide_warnings_for=some/path/"`. To see what
@@ -856,6 +864,7 @@ Documentation: [Protocol Buffers][protobuf] [JS][protobuf-js]
 [labels]: http://bazel.io/docs/build-ref.html#labels
 [name]: http://bazel.io/docs/build-ref.html#name
 [managing-dependencies]: https://github.com/google/closure-compiler/wiki/Managing-Dependencies
+[output-wrapper-faq]: https://github.com/google/closure-compiler/wiki/FAQ#when-using-advanced-optimizations-closure-compiler-adds-new-variables-to-the-global-scope-how-do-i-make-sure-my-variables-dont-collide-with-other-scripts-on-the-page
 [phantomjs-bug]: https://github.com/ariya/phantomjs/issues/14028
 [phantomjs]: http://phantomjs.org/
 [protobuf]: https://github.com/google/protobuf

--- a/closure/compiler/closure_js_binary.bzl
+++ b/closure/compiler/closure_js_binary.bzl
@@ -30,6 +30,12 @@ load("//closure/private:defs.bzl",
      "difference",
      "is_using_closure_library")
 
+_STRICT_LANGUAGES = set([
+    "ECMASCRIPT6_TYPED",
+    "ECMASCRIPT6_STRICT",
+    "ECMASCRIPT5_STRICT",
+])
+
 def _impl(ctx):
   if not ctx.attr.deps:
     fail("closure_js_binary rules can not have an empty 'deps' list")
@@ -67,6 +73,8 @@ def _impl(ctx):
     args += ["--debug"]
   elif is_using_closure_library(srcs):
     args += ["--define=goog.DEBUG=false"]
+  if is_using_closure_library(srcs) and language_out in _STRICT_LANGUAGES:
+    args += ["--define=goog.STRICT_MODE_COMPATIBLE"]
   for entry_point in ctx.attr.entry_points:
     _validate_entry_point(entry_point, srcs)
     args += ["--entry_point=" + entry_point]

--- a/closure/compiler/closure_js_binary.bzl
+++ b/closure/compiler/closure_js_binary.bzl
@@ -73,6 +73,10 @@ def _impl(ctx):
   if ctx.attr.pedantic:
     args += JS_PEDANTIC_ARGS
     args += ["--use_types_for_optimization"]
+  if ctx.attr.output_wrapper:
+    if ctx.attr.output_wrapper == "%output%":
+      fail("To disable use 'output_wrapper = \"\"'")
+    args += ["--output_wrapper=%s" % ctx.attr.output_wrapper]
   args += ctx.attr.defs
   args += ["--externs=%s" % extern.path for extern in externs]
   args += ["--js=%s" % src.path for src in srcs]
@@ -156,6 +160,8 @@ closure_js_binary = rule(
         "entry_points": attr.string_list(default=[]),
         "formatting": attr.string(),
         "language": attr.string(default="ECMASCRIPT3"),
+        "output_wrapper": attr.string(
+            default="(function(){%output%}).call(this);"),
         "pedantic": attr.bool(default=False),
         "_compiler": attr.label(
             default=Label("//closure/compiler"),

--- a/closure/compiler/closure_js_binary.bzl
+++ b/closure/compiler/closure_js_binary.bzl
@@ -28,7 +28,8 @@ load("//closure/private:defs.bzl",
      "collect_required_css_labels",
      "determine_js_language",
      "difference",
-     "is_using_closure_library")
+     "is_using_closure_library",
+     "contains_file")
 
 _STRICT_LANGUAGES = set([
     "ECMASCRIPT6_TYPED",
@@ -75,6 +76,8 @@ def _impl(ctx):
     args += ["--define=goog.DEBUG=false"]
   if is_using_closure_library(srcs) and language_out in _STRICT_LANGUAGES:
     args += ["--define=goog.STRICT_MODE_COMPATIBLE"]
+  if contains_file(srcs, ctx.file._soyutils_usegoog.short_path):
+    args += ["--define=goog.soy.REQUIRE_STRICT_AUTOESCAPE"]
   for entry_point in ctx.attr.entry_points:
     _validate_entry_point(entry_point, srcs)
     args += ["--entry_point=" + entry_point]
@@ -176,6 +179,9 @@ closure_js_binary = rule(
             executable=True),
         "_closure_library_base": CLOSURE_LIBRARY_BASE_ATTR,
         "_closure_library_deps": CLOSURE_LIBRARY_DEPS_ATTR,
+        "_soyutils_usegoog": attr.label(
+            default=Label("@soyutils_usegoog//file"),
+            single_file=True),
     },
     outputs={
         "out": "%{name}.js",

--- a/closure/compiler/closure_js_binary.bzl
+++ b/closure/compiler/closure_js_binary.bzl
@@ -84,6 +84,11 @@ def _impl(ctx):
   if ctx.attr.pedantic:
     args += JS_PEDANTIC_ARGS
     args += ["--use_types_for_optimization"]
+  if contains_file(srcs, "external/closure_library/closure/goog/json/json.js"):
+    # TODO(ahochhaus): Make unknownDefines an error for user supplied defines.
+    # https://github.com/bazelbuild/rules_closure/issues/79
+    args += ["--jscomp_off=unknownDefines",
+             "--define=goog.json.USE_NATIVE_JSON"]
   if ctx.attr.output_wrapper:
     if ctx.attr.output_wrapper == "%output%":
       fail("To disable use 'output_wrapper = \"\"'")

--- a/closure/compiler/test/BUILD
+++ b/closure/compiler/test/BUILD
@@ -33,7 +33,7 @@ closure_js_binary(
 
 file_test(
     name = "minification",
-    content = "console.log(\"hello world\");\n",
+    content = "(function(){console.log(\"hello world\");}).call(this);\n",
     file = "hello_bin.js",
 )
 
@@ -43,7 +43,7 @@ file_test(
                "\"version\":3,\n" +
                "\"file\":\"/closure/compiler/test/hello_bin.js\",\n" +
                "\"lineCount\":1,\n" +
-               "\"mappings\":\"AAgBAA,OAAAC,IAAA,CAAgB,aAAhB;\",\n" +
+               "\"mappings\":\"A,YAgBAA,OAAAC,IAAA,CAAgB,aAAhB;\",\n" +
                "\"sources\":[\"/closure/compiler/test/hello.js\"],\n" +
                "\"names\":[\"console\",\"log\"]\n" +
                "}\n"),
@@ -58,7 +58,7 @@ closure_js_binary(
 
 file_test(
     name = "strictOutputLanguage_addsUseStrict",
-    content = "'use strict';console.log(\"hello world\");\n",
+    content = "(function(){'use strict';console.log(\"hello world\");}).call(this);\n",
     file = "hello_es5strict_bin.js",
 )
 
@@ -88,7 +88,7 @@ closure_js_binary(
 
 file_test(
     name = "es6strictWithEs3Dep_isAllowed",
-    content = "console.log(\"hello world\");\n",
+    content = "(function(){console.log(\"hello world\");}).call(this);\n",
     file = "hello_decay_bin.js",
 )
 
@@ -108,7 +108,7 @@ closure_js_binary(
 
 file_test(
     name = "es6WithConstKeyword_getsRemoved",
-    content = "var hello=\"hello world\";console.log(hello);\n",
+    content = "(function(){var hello=\"hello world\";console.log(hello);}).call(this);\n",
     file = "es6const_bin.js",
 )
 
@@ -128,7 +128,7 @@ closure_js_binary(
 
 file_test(
     name = "es6WithArrowFunction_getsExpanded",
-    content = "var hello=function(e){return e+\" world\"};console.log(hello(\"hello\"));\n",
+    content = "(function(){var hello=function(e){return e+\" world\"};console.log(hello(\"hello\"));}).call(this);\n",
     file = "es6arrow_bin.js",
 )
 
@@ -148,7 +148,7 @@ closure_js_binary(
 
 file_test(
     name = "es6typed_works",
-    content = "var hello=\"hello world\";console.log(hello);\n",
+    content = "(function(){var hello=\"hello world\";console.log(hello);}).call(this);\n",
     file = "es6typed_bin.js",
 )
 
@@ -176,4 +176,30 @@ closure_js_library(
     name = "empty_lib",  # this is an alias rule
     visibility = ["//closure/compiler/test/exports_and_entry_points:__pkg__"],
     exports = [":empty_lib_indirectly_hidden"],
+)
+
+closure_js_binary(
+    name = "hello_no_output_wrapper_bin",
+    language = "ECMASCRIPT3",
+    deps = [":hello_lib"],
+    output_wrapper = "",
+)
+
+file_test(
+    name = "no_output_wrapper",
+    content = "console.log(\"hello world\");\n",
+    file = "hello_no_output_wrapper_bin.js",
+)
+
+closure_js_binary(
+    name = "hello_output_wrapper_dash_dash_space_bin",
+    language = "ECMASCRIPT3",
+    deps = [":hello_lib"],
+    output_wrapper = "-- %output%",
+)
+
+file_test(
+    name = "output_wrapper_dash_dash_space",
+    content = "-- console.log(\"hello world\");\n",
+    file = "hello_output_wrapper_dash_dash_space_bin.js",
 )

--- a/closure/compiler/test/exports_and_entry_points/BUILD
+++ b/closure/compiler/test/exports_and_entry_points/BUILD
@@ -40,7 +40,7 @@ closure_js_binary(
 
 file_test(
     name = "fileWithoutNamespacesExportsOrEntryPoints_producesBinaryThatExecutesCodeInGlobalNamespace",
-    content = "console.log(\"hi\");\n",
+    content = "(function(){console.log(\"hi\");}).call(this);\n",
     file = "program_bin.js",
 )
 
@@ -65,7 +65,7 @@ closure_js_binary(
 
 file_test(
     name = "es6_exportedFunction_isOnlyThingInResultingBinary",
-    content = "function a(){console.log(\"hi\")}var b=[\"iWillGoIntoTheBinary\"],c=this;b[0]in c||!c.execScript||c.execScript(\"var \"+b[0]);for(var d;b.length&&(d=b.shift());)b.length||void 0===a?c[d]?c=c[d]:c=c[d]={}:c[d]=a;\n",
+    content = "(function(){function a(){console.log(\"hi\")}var b=[\"iWillGoIntoTheBinary\"],c=this;b[0]in c||!c.execScript||c.execScript(\"var \"+b[0]);for(var d;b.length&&(d=b.shift());)b.length||void 0===a?c[d]?c=c[d]:c=c[d]={}:c[d]=a;}).call(this);\n",
     file = "library_bin.js",
 )
 
@@ -94,7 +94,7 @@ file_test(
     name = "goog_exportedFunction_isOnlyThingInResultingBinary",
     # This looks more complicated than you'd expect, because it's actually
     # compiling the synthetic goog.exportSymbol() call that @export generates.
-    content = "function a(){console.log(\"hi\")}var b=[\"io\",\"bazel\",\"rules\",\"closure\",\"iWillGoIntoTheBinary\"],c=this;b[0]in c||!c.execScript||c.execScript(\"var \"+b[0]);for(var d;b.length&&(d=b.shift());)b.length||void 0===a?c[d]?c=c[d]:c=c[d]={}:c[d]=a;\n",
+    content = "(function(){function a(){console.log(\"hi\")}var b=[\"io\",\"bazel\",\"rules\",\"closure\",\"iWillGoIntoTheBinary\"],c=this;b[0]in c||!c.execScript||c.execScript(\"var \"+b[0]);for(var d;b.length&&(d=b.shift());)b.length||void 0===a?c[d]?c=c[d]:c=c[d]={}:c[d]=a;}).call(this);\n",
     file = "library_goog_bin.js",
 )
 
@@ -115,7 +115,7 @@ closure_js_binary(
 
 file_test(
     name = "strictModeGlobalCodeNotListedInEntryPoints_codeGoesPoof",
-    content = "\n",
+    content = "(function(){}).call(this);\n",
     file = "program_strict_bin.js",
 )
 
@@ -131,6 +131,6 @@ closure_js_binary(
 
 file_test(
     name = "strictModeGlobalCodeIsListedInEntryPoints_codeShowsUp",
-    content = "console.log(\"hi\");\n",
+    content = "(function(){console.log(\"hi\");}).call(this);\n",
     file = "program_strict_bin2.js",
 )

--- a/closure/compiler/test/strict_dependency_checking/BUILD
+++ b/closure/compiler/test/strict_dependency_checking/BUILD
@@ -307,6 +307,6 @@ closure_js_binary(
 
 file_test(
     name = "es6ModulesWithRootPaths_compileCorrectlyWhenReferencedWithoutRootPrefix",
-    content = "console.log(\"hi\");\n",
+    content = "(function(){console.log(\"hi\");}).call(this);\n",
     file = "es6_g2_bin.js",
 )

--- a/closure/private/defs.bzl
+++ b/closure/private/defs.bzl
@@ -138,7 +138,7 @@ def determine_js_language(ctx, normalize=False):
   return language
 
 def is_using_closure_library(srcs):
-  return _contains_file(srcs, "external/closure_library/closure/goog/base.js")
+  return contains_file(srcs, "external/closure_library/closure/goog/base.js")
 
 # Maps (current, dependent) -> (compatible, is_decay)
 _JS_LANGUAGE_COMBINATIONS = {
@@ -187,7 +187,7 @@ def _mix_js_languages(ctx, current, dependent):
     return compatible
   fail("Can not link an %s library against an %s one." % (dependent, current))
 
-def _contains_file(srcs, path):
+def contains_file(srcs, path):
   for src in srcs:
     if src.short_path == path:
       return True

--- a/closure/stylesheets/test/BUILD
+++ b/closure/stylesheets/test/BUILD
@@ -93,7 +93,7 @@ closure_js_binary(
 
 file_test(
     name = "jsBinaryReferencesCssBinary_googGetCssNameCallsGetRewritten",
-    content = "console.log(\"a-b\");\n",
+    content = "(function(){console.log(\"a-b\");}).call(this);\n",
     file = "rename_bin.js",
 )
 

--- a/closure/templates/closure_template_java_library.bzl
+++ b/closure/templates/closure_template_java_library.bzl
@@ -108,7 +108,6 @@ def _gen_soy_java_wrappers(name, java_package, srcs, deps, outs,
     soycompilerbin = str(Label('//closure/templates:SoyParseInfoGenerator')),
     **kwargs):
   additional_flags = ''
-  targets = " ".join(["$(locations " + src + ")" for src in srcs])
   srcs_flag_file_name = name + '__srcs'
   deps_flag_file_name = name + '__deps'
   _soy__gen_file_list_arg_as_file(


### PR DESCRIPTION
I find myself adding certain boilerplate in nearly every `closure_js_binary()`. What do you think of setting up a few common defines (`goog.STRICT_MODE_COMPATIBLE`, `goog.soy.REQUIRE_STRICT_AUTOESCAPE`) and an output wrapper automatically?