### PR TITLE
Add incremental-dom support to closure_template_js_library()

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Closure Rules bundles the following tools and makes them "just work."
 - [Protocol Buffers][protobuf]: Google's language-neutral, platform-neutral,
   extensible mechanism for serializing structured data. This is used instead of
   untyped JSON.
+- [Incremental DOM][incremental-dom]: Google's in-place DOM diffing library.
+  This optional backend for Closure Templates builds DOM trees and updates
+  them in-place when data changes.
 
 The Closure Tools were released to the public in 2009, but had previously been
 quite difficult to configure. They were originally designed to be used with
@@ -546,7 +549,7 @@ closure_template_js_library(name, srcs, deps, globals, plugin_modules,
                             should_generate_js_doc,
                             should_provide_require_soy_namespaces,
                             should_generate_soy_msg_defs,
-                            soy_msgs_are_external)
+                            soy_msgs_are_external, incremental_dom)
 ```
 
 Compiles Closure templates to JavaScript source files.
@@ -593,16 +596,23 @@ the following:
   Passed along verbatim to the SoyToJsSrcCompiler above.
 
 - **should_generate_js_doc:** (Boolean; optional; default is `True`) Passed
-  along verbatim to the SoyToJsSrcCompiler above.
+  along verbatim to the SoyToJsSrcCompiler above. Does not apply when using
+  Incremental DOM.
 
 - **should_provide_require_soy_namespaces:** (Boolean; optional; default is
-  `True`) Passed along verbatim to the SoyToJsSrcCompiler above.
+  `True`) Passed along verbatim to the SoyToJsSrcCompiler above. Does not apply
+  when using Incremental DOM.
 
 - **should_generate_soy_msg_defs:** (Boolean; optional; default is `False`)
-  Passed along verbatim to the SoyToJsSrcCompiler above.
+  Passed along verbatim to the SoyToJsSrcCompiler above.  Does not apply when
+  using Incremental DOM.
 
 - **soy_msgs_are_external:** (Boolean; optional; default is `False`) Passed
-  along verbatim to the SoyToJsSrcCompiler above.
+  along verbatim to the SoyToJsSrcCompiler above. Does not apply when using
+  Incremental DOM.
+
+- **incremental_dom:** (Boolean; optional; default is `False`) Generate
+  [incremental-dom][incremental-dom] compatible templates.
 
 
 ## closure\_template\_java\_library
@@ -858,6 +868,7 @@ Documentation: [Protocol Buffers][protobuf] [JS][protobuf-js]
 [dependency]: http://bazel.io/docs/build-ref.html#dependencies
 [es6]: http://es6-features.org/
 [entry-export]: https://github.com/bazelbuild/rules_closure/blob/master/closure/compiler/test/exports_and_entry_points/BUILD
+[incremental-dom]: https://github.com/google/incremental-dom/
 [java-exports]: http://bazel.io/docs/be/java.html#java_library.exports
 [jsstyle]: https://google.github.io/styleguide/javascriptguide.xml
 [jquery]: http://jquery.com/

--- a/closure/compiler/closure_js_binary.bzl
+++ b/closure/compiler/closure_js_binary.bzl
@@ -85,7 +85,7 @@ def _impl(ctx):
     args += JS_PEDANTIC_ARGS
     args += ["--use_types_for_optimization"]
   if contains_file(srcs, "external/closure_library/closure/goog/json/json.js"):
-    # TODO(ahochhaus): Make unknownDefines an error for user supplied defines.
+    # TODO(hochhaus): Make unknownDefines an error for user supplied defines.
     # https://github.com/bazelbuild/rules_closure/issues/79
     args += ["--jscomp_off=unknownDefines",
              "--define=goog.json.USE_NATIVE_JSON"]

--- a/closure/private/defs.bzl
+++ b/closure/private/defs.bzl
@@ -43,8 +43,9 @@ JS_PEDANTIC_ARGS = [
 
 JS_HIDE_WARNING_ARGS = [
     "--hide_warnings_for=external/closure_library/",
-    "--hide_warnings_for=external/soyutils_usegoog/",
+    "--hide_warnings_for=external/incremental_dom/",
     "--hide_warnings_for=external/protobuf_js/",
+    "--hide_warnings_for=external/soyutils_usegoog/",
     "--hide_warnings_for=bazel-out/local-fastbuild/genfiles/",
 ]
 

--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -34,6 +34,8 @@ def closure_repositories(
     omit_guice_assistedinject=False,
     omit_guice_multibindings=False,
     omit_icu4j=False,
+    omit_incremental_dom = False,
+    omit_incremental_dom_soy = False,
     omit_jsr305=False,
     omit_jsr330_inject=False,
     omit_libexpat_amd64_deb=False,
@@ -82,6 +84,10 @@ def closure_repositories(
     guice_multibindings()
   if not omit_icu4j:
     icu4j()
+  if not omit_incremental_dom:
+    incremental_dom()
+  if not omit_incremental_dom_soy:
+    incremental_dom_soy()
   if not omit_jsr305:
     jsr305()
   if not omit_jsr330_inject:
@@ -289,6 +295,28 @@ def icu4j():
       server = "closure_maven_server",
   )
 
+def incremental_dom():
+  # To update Incremental DOM, one needs to update
+  # third_party/incremental_dom/build.sh to remain compatible with the
+  # upstream "js-closure" gulpfile.js target.
+  # https://github.com/google/incremental-dom/blob/master/gulpfile.js
+  native.http_file(
+      name = "incremental_dom",
+      url = "http://bazel-mirror.storage.googleapis.com/github.com/google/incremental-dom/archive/0.4.0.tar.gz",
+      sha256 = "f8abce145b235e1b0f94f2d923e49c49c16c9bca462ecfcc7e787ae15d84fc74",
+  )
+
+def incremental_dom_soy():
+  native.new_http_archive(
+      name = "incremental_dom_soy",
+      # TODO(hochhaus): Use soy jar when SoyToIncrementalDomSrcCompiler is
+      # synced to github.
+      # https://github.com/google/closure-templates/issues/85
+      url = "http://bazel-mirror.storage.googleapis.com/registry.npmjs.org/closure-templates-incrementaldom/-/closure-templates-incrementaldom-0.0.3.tgz",
+      sha256 = "c72be8b1596e6ac2d2d484532803e75515d38561fded604074a287495a00bdd2",
+      build_file = str(Label("//closure/templates:incremental_dom_soy.BUILD")),
+  )
+
 def jsr305():
   native.maven_jar(
       name = "jsr305",
@@ -351,7 +379,7 @@ def protobuf_js():
   native.new_http_archive(
       name = "protobuf_js",
       # TODO(hochhaus): Use protobuf-js-*.zip once it includes encoder.js.
-      # http://github.com/google/protobuf/pull/1589
+      # https://github.com/google/protobuf/pull/1589
       url = "http://bazel-mirror.storage.googleapis.com/github.com/google/protobuf/archive/v3.0.0-beta-3.zip",
       sha256 = "dad1912814e9d9b8642036d07c086ac79faf2cc534c992911375a39924a45860",
       strip_prefix = "protobuf-3.0.0-beta-3",

--- a/closure/templates/BUILD
+++ b/closure/templates/BUILD
@@ -63,3 +63,22 @@ java_binary(
         ":templates",
     ],
 )
+
+java_binary(
+    name = "SoyToIncrementalDomSrcCompiler",
+    jvm_flags = ["-client"],
+    main_class = "com.google.template.soy.SoyToIncrementalDomSrcCompiler",
+    runtime_deps = [
+        "@args4j//jar",
+        "@incremental_dom_soy//:compiler_jar",
+    ],
+)
+
+closure_js_library(
+    name = "incremental_dom",
+    srcs = ["//third_party/incremental_dom"],
+    language = "ECMASCRIPT6_STRICT",
+    suppress = [
+        "JSC_MISSING_JSDOC",
+    ],
+)

--- a/closure/templates/incremental_dom_soy.BUILD
+++ b/closure/templates/incremental_dom_soy.BUILD
@@ -1,0 +1,20 @@
+# Copyright 2016 The Closure Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+java_import(
+  name = "compiler_jar",
+  jars = ["package/SoyToIncrementalDomSrcCompiler.jar"],
+)

--- a/closure/templates/test/BUILD
+++ b/closure/templates/test/BUILD
@@ -23,6 +23,12 @@ closure_template_js_library(
     srcs = ["greeter.soy"],
 )
 
+closure_template_js_library(
+    name = "greeter_idom_soy",
+    srcs = ["greeter_idom.soy"],
+    incremental_dom = 1,
+)
+
 closure_js_library(
     name = "greeter_lib",
     srcs = ["greeter.js"],
@@ -30,6 +36,17 @@ closure_js_library(
         ":greeter_soy",
         "//closure/library",
     ],
+)
+
+closure_js_library(
+    name = "greeter_idom_lib",
+    srcs = ["greeter_idom.js"],
+    deps = [
+        ":greeter_idom_soy",
+        "//closure/library",
+        "//closure/templates:incremental_dom",
+    ],
+    language = "ECMASCRIPT6_STRICT",
 )
 
 closure_js_test(
@@ -41,4 +58,14 @@ closure_js_test(
         "//closure/library",
         "//closure/library:testing",
     ],
+)
+
+closure_js_test(
+    name = "greeter_idom_test",
+    srcs = ["greeter_idom_test.js"],
+    deps = [
+        ":greeter_idom_lib",
+        "//closure/library:testing",
+    ],
+    language = "ECMASCRIPT6_STRICT",
 )

--- a/closure/templates/test/greeter_idom.js
+++ b/closure/templates/test/greeter_idom.js
@@ -1,0 +1,45 @@
+// Copyright 2016 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+goog.module('io.bazel.rules.closure.GreeterIdom');
+
+const idom = goog.require('incrementaldom');
+const greeter = goog.require('io.bazel.rules.closure.soy.greeter.incrementaldom');
+
+
+
+exports = class GreeterIdom {
+  /**
+   * Greeter page.
+   * @param {string} name Name of person to greet.
+   */
+  constructor(name) {
+    /**
+     * Name of person to greet.
+     * @private {string}
+     * @const
+     */
+    this.name_ = name;
+  }
+
+  /**
+   * Renders HTML greeting as document body.
+   */
+  greet() {
+    idom.patchInner(goog.global.document.body, greeter.greet,
+                    {name: this.name_});
+  }
+};
+
+

--- a/closure/templates/test/greeter_idom.soy
+++ b/closure/templates/test/greeter_idom.soy
@@ -1,0 +1,26 @@
+// Copyright 2016 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{namespace io.bazel.rules.closure.soy.greeter autoescape="strict"}
+
+
+/**
+ * Greets a person.
+ */
+{template .greet}
+  {@param name: string}
+  <p>
+    Hello <b>{$name}</b>!
+  </p>
+{/template}

--- a/closure/templates/test/greeter_idom_test.js
+++ b/closure/templates/test/greeter_idom_test.js
@@ -1,0 +1,29 @@
+// Copyright 2016 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+goog.require('goog.testing.asserts');
+goog.require('goog.testing.jsunit');
+goog.require('goog.testing.testSuite');
+goog.require('io.bazel.rules.closure.GreeterIdom');
+
+goog.testing.testSuite({
+
+  'testGreet': function() {
+    var GreeterIdom = goog.module.get('io.bazel.rules.closure.GreeterIdom');
+    var greeter = new GreeterIdom('Andy');
+    greeter.greet();
+    assertHTMLEquals('<p>Hello <b>Andy</b>!</p>', document.body.innerHTML);
+  }
+
+});  // goog.testing.testSuite

--- a/third_party/incremental_dom/BUILD
+++ b/third_party/incremental_dom/BUILD
@@ -1,0 +1,38 @@
+# Copyright 2016 The Closure Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])  # Apache License Version 2.0
+
+sh_binary(
+    name = "build",
+    srcs = ["build.sh"],
+)
+
+genrule(
+    name = "incremental_dom",
+    srcs = ["@incremental_dom//file"],
+    outs = ["incremental-dom-closure.js"],
+    cmd = " && ".join([
+        "IN=$$(pwd)/$(SRCS)",
+        "OUT=$$(pwd)/$@",
+        "TMP=$$(mktemp -d $${TMPDIR:-/tmp}/genrule.XXXXXXXXXX)",
+        "SCRIPT=$$(pwd)/$(location :build)",
+        "cd $$TMP",
+        "$$SCRIPT $$IN $$OUT",
+        "rm -rf $$TMP",
+    ]),
+    tools = [ ":build" ],
+)

--- a/third_party/incremental_dom/build.sh
+++ b/third_party/incremental_dom/build.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# Copyright 2016 The Closure Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Upstream Incremental DOM is written using ES6 modules. A gulp file is also
+# included which uses Rollup to generate a goog.module() style closure-library
+# compatible file:
+#
+#   https://github.com/google/incremental-dom/blob/master/gulpfile.js
+#
+# To avoid the runtime dependencies on gulp/node/rollup/etc this script
+# converts upstream Incremental DOM ES6 sources into a goog.module() version.
+# Therefore, the upstream gulpfile.js need not be used. This script must be
+# kept up to date with the "js-closure" target when updating incremental_dom.
+
+set -e
+set -u
+
+tar xfz $1 --strip 1;
+
+echo "goog.module('incrementaldom');" > $2;
+
+cat src/util.js \
+    src/node_data.js \
+    src/symbols.js \
+    src/attributes.js \
+    src/nodes.js \
+    src/notifications.js \
+    src/context.js \
+    src/assertions.js \
+    src/core.js \
+    src/virtual_elements.js | \
+    tr '\n' '\r' | \
+    sed 's/export [^;]*;//g' | \
+    sed 's/import [^;]*;//g' | \
+    sed "s/process.env.NODE_ENV/'undefined'/g" | \
+    sed 's/const elementOpen /const coreElementOpen /' | \
+    sed 's/const elementClose /const coreElementClose /' | \
+    sed 's/const text /const coreText /' | \
+    tr '\r' '\n' >> $2;
+
+cat index.js | \
+    sed 's/export { \([^ ]*\) } from [^;]*;/  \1/' | \
+    grep "^  " | \
+    sed 's/,$//' | \
+    sed 's/^  \([^ ]*\) as \([^ ]*\)$/exports\.\2 = \1;/' | \
+    sed 's/^  \([^ ]*\)$/exports\.\1 = \1;/' >> $2;


### PR DESCRIPTION
FYI, the tests will fail until the idom *.tar.gz is mirrored.

I'm happy to make any fixes so please let me know what you spot that could be done better. I'm currently leaving this as a macro. I plan to convert closure_proto_library/closure_template_js_library to a rule as time permits in the future.