### PR TITLE
Enforce style with clang-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,39 @@ maven_jar(
 )
 ```
 
+### Source code formatting
+
+It is recomended that you configure your editor to format your JavaScript and
+Protocol Buffer source files automatically at save. Doing so makes it easy to
+follow Google coding style conventions.
+
+#### Emacs
+
+This section configures `js2-mode` as your major mode for JavaScript editing
+and uses `clang-format` to format JavaScript and Protocol Buffer source files
+automatically when saving. Depending on your preferences you may need to
+customize these instructions. You will also need to ensure that `clang-format`
+is in your `PATH`.
+
+If you aren't already using MELPA, see:
+http://melpa.milkbox.net/#/getting-started
+Then, use `M-x install-package` to install the following three packages:
+
+  * `clang-format`
+  * `js2-mode`
+  * `protobuf-mode`
+
+Finally add the following to your `.emacs` file:
+
+```lisp
+(setq-default js2-basic-offset 2)
+(add-to-list 'auto-mode-alist '("\\.js\\'" . js2-mode))
+(eval-after-load 'js2-mode
+  '(add-hook 'before-save-hook (lambda () (clang-format-buffer '"Google"))))
+(eval-after-load 'protobuf-mode
+  '(add-hook 'before-save-hook (lambda () (clang-format-buffer '"Google"))))
+```
+
 ## Examples
 
 Please see the test directories within this project for concrete examples of usage:
@@ -945,7 +978,7 @@ This rule can be referenced as though it were the following:
 ```python
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_proto_library")
 closure_js_proto_library(name, srcs, add_require_for_enums, binary,
-                         import_style)
+                         import_style, style)
 ```
 
 Defines a set of Protocol Buffer files.
@@ -993,6 +1026,11 @@ This rule can be referenced as though it were the following:
   - `IMPORT_COMMONJS`   // require()
   - `IMPORT_BROWSER`    // no import statements
   - `IMPORT_ES6`        // import { member } from ''
+
+- **style** (Boolean; optional; default is `True`) Enforce Google coding style
+  conventions with [ClangFormat][clang-format]. It is strongly recommended that
+  you [configure](#source-code-formatting) your editor to run clang-format
+  automatically at save.
 
 
 [Bazel]: http://bazel.io/

--- a/closure/library/BUILD
+++ b/closure/library/BUILD
@@ -22,6 +22,7 @@ closure_js_library(
     srcs = ["@closure_library//:js_library_files"],
     language = "ECMASCRIPT5_STRICT",
     suppress = [
+        "CLANG_FORMAT",
         "JSC_DUPLICATE_ENUM_VALUE",
         "JSC_ILLEGAL_PROTOTYPE_MEMBER",
         "JSC_INVALID_SUPPRESS",
@@ -40,6 +41,7 @@ closure_js_library(
     srcs = ["@closure_library//:js_testing_files"],
     language = "ECMASCRIPT5_STRICT",
     suppress = [
+        "CLANG_FORMAT",
         "JSC_EXTRA_REQUIRE_WARNING",
         "JSC_INVALID_SUPPRESS",
         "JSC_MISSING_JSDOC",

--- a/closure/protobuf/BUILD
+++ b/closure/protobuf/BUILD
@@ -20,6 +20,7 @@ closure_js_library(
     name = "jspb",
     srcs = ["@protobuf_js//:proto_js_library_files"],
     suppress = [
+        "CLANG_FORMAT",
         "JSC_EXTRA_REQUIRE_WARNING",
         "JSC_OPTIONAL_PARAM_NOT_MARKED_OPTIONAL",
     ],

--- a/closure/templates/BUILD
+++ b/closure/templates/BUILD
@@ -58,6 +58,7 @@ closure_js_library(
     name = "soy_jssrc",
     srcs = ["//third_party/jssrc"],
     suppress = [
+        "CLANG_FORMAT",
         "JSC_OPTIONAL_PARAM_NOT_MARKED_OPTIONAL",
     ],
     deps = [
@@ -120,4 +121,8 @@ closure_js_library(
     name = "incremental_dom",
     srcs = ["//third_party/incremental_dom"],
     language = "ECMASCRIPT6_STRICT",
+    suppress = [
+        "CLANG_FORMAT",
+        "JSC_MISSING_JSDOC",
+    ],
 )

--- a/closure/templates/closure_js_template_library.bzl
+++ b/closure/templates/closure_js_template_library.bzl
@@ -131,6 +131,9 @@ def closure_js_template_library(
       deps = deps,
       visibility = visibility,
       testonly = testonly,
+      suppress = [
+          "CLANG_FORMAT",
+      ],
   )
 
 

--- a/third_party/llvm/llvm/tools/clang/BUILD
+++ b/third_party/llvm/llvm/tools/clang/BUILD
@@ -2,6 +2,14 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # BSD
 
+sh_binary(
+    name = "google_format",
+    srcs = ["google_format.sh"],
+    data = [
+        "clang-format",
+    ],
+)
+
 genrule(
     name = "clang_format_extract",
     srcs = ["@clang//file"],

--- a/third_party/llvm/llvm/tools/clang/google_format.sh
+++ b/third_party/llvm/llvm/tools/clang/google_format.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Copyright 2016 The Closure Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# clang-format's intended use case is to automatically reformat source files
+# without need for human intervention. Therefore the primary means of source
+# code formatting should be performed automatically from the editor. This
+# script checks returns success if no reformatting is required. However, if
+# reformatting is required an error is returned. In this case, the source file
+# is _not_ reformatted. Instead, the user must invoke clang-format (possibly
+# via their editor) in order for the source input file to be formatted.
+
+set -e
+set -u
+
+$1 -style=Google -output-replacements-xml "${@:3}" | \
+    { grep "<replacement " || true; } > $2;
+
+if [[ -s "$2" ]]; then
+  echo "Source files do not follow Google coding conventions."
+  echo "It is recomended that you configure your editor to ensure that all"
+  echo "files are formatted correctly at save. For details, see:"
+  echo "https://github.com/bazelbuild/rules_closure#source-code-formatting"
+  echo "Malformed files: ${@:3}";
+  exit 1;
+fi


### PR DESCRIPTION
Unfortunately, I think the design of this change will still require a fair bit of discussion. I'm not sure the best way to lay in the style enforcement.

The source of the issue is that clang-format's intended use case is to automatically re-format files into the correct syntax. This is amazing when clang-format is run from your editor's save hook. However, I wanted something a bit stricter than just relying on each team member to configure their editor correctly. Therefore, this change breaks the compile if any `*.{js,proto}` file requires reformatting. However, it will not automatically reformat the source files. (This is good I think since changing the _inputs_ to the build during the build seems horrible.) Instead the user must invoke clang-format (either from their editor or from the command line) to reformat the file.

I think at least the following items need discussion during the merge:
- I added emacs specific documentation since that is the only editor I know well enough to configure. Do we need docs for other editors prior to merge? Is editor specific documentation acceptable?
- In the case where clang-format is run automatically at save from the editor `style = True` should never catch any errors. We hope this to be the common case. What should the error say/do when this isn't the case? What is the correct way to return a nice error message to the user here? Just "exit 1"?
- Is referencing external MELPA sources for editor configuration acceptable?
- What is the correct way to setup the editor to locate the clang-format binary? Referencing the copy in external/ seem sloppy since the user could have multiple clones of different repos which all depend on rules_closure. Alternatively, having the user install a separate copy also seems messy since thje version might skew with the rules_closure managed version.