### PR TITLE
Make JsChecker a Bazel worker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ before_install:
   - ./bazel-0.2.2b-installer-linux-x86_64.sh --user
 
 script:
-  - bazel --batch --host_jvm_args=-Xmx1000m --host_jvm_args=-Xms1000m test closure/... --verbose_failures --test_output=errors --test_strategy=standalone --spawn_strategy=standalone --genrule_strategy=standalone --local_resources=1000,1,1.0
+  - bazel --batch --host_jvm_args=-Xmx1000m --host_jvm_args=-Xms1000m test closure/... --strategy=Javac=worker --strategy=JsChecker=worker --worker_verbose --verbose_failures --test_output=errors --test_strategy=standalone --spawn_strategy=standalone --genrule_strategy=standalone --local_resources=1000,1,1.0

--- a/closure/compiler/closure_js_library.bzl
+++ b/closure/compiler/closure_js_library.bzl
@@ -68,12 +68,16 @@ def _impl(ctx):
     args += ["--expect_failure"]
   if ctx.attr.internal_expect_warnings:
     args += ["--expect_warnings"]
+  argfile = ctx.new_file(ctx.configuration.bin_dir,
+                         "%s_worker_input" % ctx.label.name)
+  ctx.file_action(output=argfile, content="\n".join(args))
+  inputs.append(argfile)
   ctx.action(
       inputs=inputs,
       outputs=[ctx.outputs.provided, ctx.outputs.stderr],
       executable=ctx.executable._jschecker,
-      arguments=args,
-      mnemonic="JSChecker",
+      arguments=["@" + argfile.path],
+      mnemonic="JsChecker",
       progress_message="Checking %d JS files in %s" % (
           len(ctx.files.srcs) + len(ctx.files.externs), ctx.label))
   return struct(files=set(ctx.files.srcs, order="compile"),

--- a/closure/private/BUILD
+++ b/closure/private/BUILD
@@ -12,4 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//closure:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
+
+sh_binary(
+    name = "gensrcjar",
+    srcs = ["gensrcjar.sh"],
+)

--- a/closure/private/gensrcjar.sh
+++ b/closure/private/gensrcjar.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+#
+# Copyright 2016 The Closure Rules Authors. All rights reserved.
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# List of environment variables that must be defined as input.
+#
+# We use environment variables instead of positional arguments or flags for
+# clarity in the caller .bzl file and for simplicity of processing.  There is no
+# need to implement a full-blown argument parser for this simple script.
+INPUT_VARS="JAR OUTPUT PREPROCESSOR PROTO_COMPILER SOURCE"
+
+# Now set defaults for optional input variables.
+: "${PREPROCESSOR:=cat}"
+
+# Basename of the script for error reporting purposes.
+PROGRAM_NAME="${0##*/}"
+
+# A timestamp to mark all generated files with to get deterministic JAR outputs.
+TIMESTAMP=198001010000
+
+# Prints an error and exits.
+#
+# Args:
+#   ...: list(str).  Parts of the message to print; all of them are joined
+#       with a single space in between.
+err() {
+  echo "${PROGRAM_NAME}: ${*}" 1>&2
+  exit 1
+}
+
+# Entry point.
+main() {
+  [ ${#} -eq 0 ] || err "No arguments allowed; set the following environment" \
+      "variables for configuration instead: ${INPUT_VARS}"
+  for var in ${INPUT_VARS}; do
+    local value
+    eval "value=\"\$${var}\""
+    [ -n "${value}" ] || err "Input environment variable ${var} is not set"
+  done
+
+  rm -f "${OUTPUT}"
+
+  local proto_output="${OUTPUT}.proto_output"
+  rm -rf "${proto_output}"
+  mkdir -p "${proto_output}"
+
+  # Apply desired preprocessing to the input proto file.  For this to work, we
+  # must maintain the name of the original .proto file or else the generated
+  # classes in the JAR file would have an invalid name.
+  local processed_dir="${OUTPUT}.preprocessed"
+  rm -rf "${processed_dir}"
+  mkdir -p "${processed_dir}"
+  local processed_source="${processed_dir}/$(basename "${SOURCE}")"
+  "${PREPROCESSOR}" <"${SOURCE}" >"${processed_source}" \
+      || err "Preprocessor ${PREPROCESSOR} failed"
+
+  if [ -n "${GRPC_JAVA_PLUGIN}" ]; then
+    "${PROTO_COMPILER}" --plugin=protoc-gen-grpc="${GRPC_JAVA_PLUGIN}" \
+        --grpc_out="${proto_output}" --java_out="${proto_output}" "${processed_source}" \
+        || err "proto_compiler failed"
+  else
+    "${PROTO_COMPILER}" --java_out="${proto_output}" "${processed_source}" \
+        || err "proto_compiler failed"
+  fi
+  find "${proto_output}" -exec touch -t "${TIMESTAMP}" '{}' \; \
+      || err "Failed to reset timestamps"
+  "${JAR}" cMf "${OUTPUT}.tmp" -C "${proto_output}" . \
+      || err "jar failed"
+  mv "${OUTPUT}.tmp" "${OUTPUT}"
+}
+
+main "${@}"

--- a/closure/private/java_proto_library.bzl
+++ b/closure/private/java_proto_library.bzl
@@ -1,0 +1,76 @@
+# -*- mode: python; -*-
+#
+# Copyright 2016 The Closure Rules Authors. All rights reserved.
+# Copyright 2014 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def _impl(ctx):
+  out = ctx.outputs.srcjar
+  ctx.action(
+      command=' '.join([
+          "JAR='%s'" % ctx.executable._jar.path,
+          "OUTPUT='%s'" % out.path,
+          "PROTO_COMPILER='%s'" % ctx.executable._proto_compiler.path,
+          "SOURCE='%s'" % ctx.file.src.path,
+          ctx.executable._gensrcjar.path,
+      ]),
+      inputs=([ctx.file.src] + ctx.files._gensrcjar + ctx.files._jar +
+              ctx.files._jdk + ctx.files._proto_compiler),
+      outputs=[out],
+      mnemonic="GenProtoSrcJar",
+      use_default_shell_env=True)
+  return struct(runfiles=ctx.runfiles(collect_default=True))
+
+_gensrcjar = rule(
+    implementation=_impl,
+    attrs = {
+        "src": attr.label(
+            allow_files = FileType([".proto"]),
+            single_file = True),
+        "_gensrcjar": attr.label(
+            default = Label(str(Label("//closure/private:gensrcjar"))),
+            executable = True),
+        "_proto_compiler": attr.label(
+            default = Label("//third_party/protobuf:protoc"),
+            allow_files = True,
+            executable = True,
+            single_file = True),
+        "_jar": attr.label(
+            default = Label("@local_jdk//:jar"),
+            allow_files = True,
+            executable = True,
+            single_file = True),
+        "_jdk": attr.label(
+            default = Label("@local_jdk//:jdk-default"),
+            allow_files = True),
+    },
+    outputs = {"srcjar": "lib%{name}.srcjar"})
+
+def java_proto_library(name, src, testonly=None, visibility=None, **kwargs):
+  _gensrcjar(
+      name = name + "_srcjar",
+      src = src,
+      testonly = testonly,
+      visibility = visibility,
+  )
+
+  native.java_library(
+      name = name,
+      srcs = [":%s_srcjar" % name],
+      deps = ["@protobuf_java//jar"],
+      javacopts = ["-Xlint:-rawtypes"],
+      testonly = testonly,
+      visibility = visibility,
+      **kwargs
+  )

--- a/java/com/google/javascript/jscomp/BUILD
+++ b/java/com/google/javascript/jscomp/BUILD
@@ -1,3 +1,5 @@
+load("//closure/private:java_proto_library.bzl", "java_proto_library")
+
 java_binary(
     name = "jschecker",
     srcs = [
@@ -11,13 +13,18 @@ java_binary(
         "JsCheckerSecondPass.java",
         "JsCheckerState.java",
     ],
-    jvm_flags = ["-client"],
     main_class = "com.google.javascript.jscomp.JsChecker",
     visibility = ["//visibility:public"],
     deps = [
         "@args4j//jar",
         "@guava//jar",
         "@protobuf_java//jar",
+        ":worker_protocol_proto",
         "//third_party/java/jscomp",
     ],
+)
+
+java_proto_library(
+    name = "worker_protocol_proto",
+    src = "worker_protocol.proto",
 )

--- a/java/com/google/javascript/jscomp/worker_protocol.proto
+++ b/java/com/google/javascript/jscomp/worker_protocol.proto
@@ -1,0 +1,51 @@
+// Copyright 2015 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package blaze.worker;
+
+option java_package = "com.google.devtools.build.lib.worker";
+
+// An input file.
+message Input {
+  // The path in the file system where to read this input artifact from. This is
+  // either a path relative to the execution root (the worker process is
+  // launched with the working directory set to the execution root), or an
+  // absolute path.
+  string path = 1;
+
+  // A hash-value of the contents. The format of the contents is unspecified and
+  // the digest should be treated as an opaque token.
+  bytes digest = 2;
+}
+
+// This represents a single work unit that Blaze sends to the worker.
+message WorkRequest {
+  repeated string arguments = 1;
+
+  // The inputs that the worker is allowed to read during execution of this
+  // request.
+  repeated Input inputs = 2;
+}
+
+// The worker sends this message to Blaze when it finished its work on the WorkRequest message.
+message WorkResponse {
+  int32 exit_code = 1;
+
+  // This is printed to the user after the WorkResponse has been received and is supposed to contain
+  // compiler warnings / errors etc. - thus we'll use a string type here, which gives us UTF-8
+  // encoding.
+  string output = 2;
+}


### PR DESCRIPTION
I'm following through on @damienmg's suggestion in #77.

This change significantly improves the performance of closure_js_library when `--strategy=JsChecker=worker` is passed to Bazel. Now it won't have to spin up a new JVM for every single library rule. This will be indispensable for projects that have one library rule for every js file. It also helps alleviates @pcj's concerns. However this only applies to library rules at the moment. I haven't implemented this for binary rules yet.

I copied some code from the Bazel codebase because I'm afraid to link against `@closure_tools//...` in the interest of hermeticism. I hope I'm doing things correctly.

CC: @philwo @hochhaus 