### PR TITLE
Add safe-html-types  html.proto generation

### DIFF
--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -51,6 +51,7 @@ def closure_repositories(
     omit_protoc_linux_x86_64=False,
     omit_protoc_macosx=False,
     omit_safe_html_types=False,
+    omit_safe_html_types_html_proto=False,
     omit_soy=False,
     omit_soy_jssrc=False):
   closure_maven_server()
@@ -118,6 +119,8 @@ def closure_repositories(
     protoc_macosx()
   if not omit_safe_html_types:
     safe_html_types()
+  if not omit_safe_html_types_html_proto:
+    safe_html_types_html_proto()
   if not omit_soy:
     soy()
   if not omit_soy_jssrc:
@@ -423,6 +426,13 @@ def safe_html_types():
       artifact = "com.google.common.html.types:types:1.0.4",
       sha1 = "2adf4c8bfccc0ff7346f9186ac5aa57d829ad065",
       server = "closure_maven_server",
+  )
+
+def safe_html_types_html_proto():
+  native.http_file(
+      name = "safe_html_types_html_proto",
+      sha256 = "63fa9410f262b4e57588cdad19196d96a1052234d81212c3356728199c2de393",
+      url = "http://bazel-mirror.storage.googleapis.com/github.com/google/safe-html-types/archive/release-1.0.4.tar.gz",
   )
 
 def soy():

--- a/closure/templates/BUILD
+++ b/closure/templates/BUILD
@@ -15,6 +15,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//closure:defs.bzl", "closure_js_library")
+load("//closure:defs.bzl", "closure_js_proto_library")
 
 java_library(
     name = "templates",
@@ -48,13 +49,21 @@ java_library(
     ],
 )
 
+closure_js_proto_library(
+    name = "soy_html_proto",
+    srcs = ["//third_party/jssrc:html_proto"],
+)
+
 closure_js_library(
     name = "soy_jssrc",
     srcs = ["//third_party/jssrc"],
     suppress = [
         "JSC_OPTIONAL_PARAM_NOT_MARKED_OPTIONAL",
     ],
-    deps = ["//closure/library"],
+    deps = [
+        ":soy_html_proto",
+        "//closure/library",
+    ],
 )
 
 java_binary(

--- a/third_party/jssrc/BUILD
+++ b/third_party/jssrc/BUILD
@@ -6,9 +6,8 @@ genrule(
     name = "jssrc",
     srcs = ["@soy_jssrc//file"],
     outs = [
-        # TODO(hochhaus): Add safehtml dependency
-        # "jspbconversions.js",
-        # "soydata_converters.js",
+        "jspbconversions.js",
+        "soydata_converters.js",
         "soyutils_usegoog.js",
     ],
     cmd = " && ".join([
@@ -17,7 +16,24 @@ genrule(
         "TMP=$$(mktemp -d $${TMPDIR:-/tmp}/genrule.XXXXXXXXXX)",
         "cd $$TMP",
         "unzip -q $$IN",
-        "mv soyutils_usegoog.js $$OUT",
+        "mv *.js $$OUT",
+        "rm -rf $$TMP",
+    ]),
+)
+
+genrule(
+    name = "html_proto",
+    srcs = ["@safe_html_types_html_proto//file"],
+    outs = [
+        "html.proto",
+    ],
+    cmd = " && ".join([
+        "IN=$$(pwd)/$(SRCS)",
+        "OUT=$$(pwd)/$@",
+        "TMP=$$(mktemp -d $${TMPDIR:-/tmp}/genrule.XXXXXXXXXX)",
+        "cd $$TMP",
+        "tar xf $$IN",
+        "mv safe-html-types-release-*/proto/src/main/protobuf/html.proto $$OUT",
         "rm -rf $$TMP",
     ]),
 )


### PR DESCRIPTION
This provides the following types which are used in the soy js
protobuf support code:

proto.webutil.html.types.SafeHtmlProto
proto.webutil.html.types.SafeScriptProto
proto.webutil.html.types.SafeStyleProto
proto.webutil.html.types.SafeStyleSheetProto
proto.webutil.html.types.SafeUrlProto
proto.webutil.html.types.TrustedResourceUrlProto