### PR TITLE
Refactor part of closure_js_template_library into a skylark rule

### DIFF
--- a/closure/private/defs.bzl
+++ b/closure/private/defs.bzl
@@ -22,6 +22,7 @@ HTML_FILE_TYPE = FileType([".html"])
 JS_FILE_TYPE = FileType([".js"])
 JS_LANGUAGE_DEFAULT = "ECMASCRIPT5_STRICT"
 JS_TEST_FILE_TYPE = FileType(["_test.js"])
+SOY_FILE_TYPE = FileType([".soy"])
 
 JS_LANGUAGES = set([
     "ANY",


### PR DESCRIPTION
I couldn't refactor all of `closure_js_template_library()` into a rule because:

 * `_closure_js_template_library()` needs to produce 1+ output(s) for which the file names are dynamically determined from the input file names. According to [the manual](https://bazel.io/versions/master/docs/skylark/rules.html#output-files) having a "output list type attribute" appears to be the only way to acomplish this with a rule.
 * `closure_js_template_library()` needs to call `closure_js_library()` which is itself a rule. According to the [multiple rules](https://bazel.io/versions/master/docs/skylark/cookbook.html#macro-multiple-rules) section of the manual there is "no easy way to create a rule that directly uses the action of a native rule".

The reason for the partial refactoring is that my upcoming change (which adds support for protobuf types in soy files) needs access to the descriptor set of the protocol buffer(s).