### PR TITLE
Set //closure/testing/test:fontdemo to local

### DIFF
--- a/closure/testing/test/BUILD
+++ b/closure/testing/test/BUILD
@@ -85,6 +85,8 @@ genrule(
     outs = ["fontdemo-generated.png"],
     cmd = "$(location //third_party/phantomjs) $(SRCS) $@",
     tools = ["//third_party/phantomjs"],
+    local = 1,
+    tags = ["requires-network"],
 )
 
 files_equal_test(


### PR DESCRIPTION
This genrule is broken by the sandbox because of a bug
in PhantomJS (ariya/phantomjs#13876).

Fixes bazelbuild/bazel#1715.