### PR TITLE
Set phantomjs_test to local

### DIFF
--- a/closure/testing/phantomjs_test.bzl
+++ b/closure/testing/phantomjs_test.bzl
@@ -72,7 +72,7 @@ def _first(iterable):
     return item
   fail("iterable was empty")
 
-phantomjs_test = rule(
+_phantomjs_test = rule(
     test=True,
     implementation=_impl,
     attrs={
@@ -94,3 +94,11 @@ phantomjs_test = rule(
             default=Label("//third_party/phantomjs"),
             allow_files=True),
     })
+
+# Workaround https://github.com/ariya/phantomjs/issues/13876 by setting
+# phantomjs_test to local.
+# TODO(dmarting): Remove when https://github.com/ariya/phantomjs/issues/13876
+# is fixed.
+def phantomjs_test(**kwargs):
+  tags = kwargs.pop("tags", [])
+  _phantomjs_test(tags = ["local"] + tags, **kwargs)

--- a/closure/testing/test/BUILD
+++ b/closure/testing/test/BUILD
@@ -85,6 +85,7 @@ genrule(
     outs = ["fontdemo-generated.png"],
     cmd = "$(location //third_party/phantomjs) $(SRCS) $@",
     tools = ["//third_party/phantomjs"],
+    # TODO(dmarting): Remove local = 1 when ariya/phantomjs#13876 is fixed.
     local = 1,
     tags = ["requires-network"],
 )


### PR DESCRIPTION
This will circumvent issue with Phantomjs failing in an OS X sandbox (ariya/phantomjs#13876)

All tests using phantomjs are currently failing. This just deactivate the sandbox for now
but might become a problem once we do remote execution in Bazel.

Tested on my mac laptop.