### PR TITLE
Fix incremental-dom-closure.js generation for 0.5.0

### DIFF
--- a/closure/templates/test/BUILD
+++ b/closure/templates/test/BUILD
@@ -16,6 +16,7 @@ package(default_testonly = True)
 
 licenses(["notice"])  # Apache 2.0
 
+load("//closure:defs.bzl", "closure_js_binary")
 load("//closure:defs.bzl", "closure_js_library")
 load("//closure:defs.bzl", "closure_js_proto_library")
 load("//closure:defs.bzl", "closure_js_template_library")
@@ -73,6 +74,17 @@ closure_js_library(
 )
 
 closure_js_library(
+    name = "greeter_idom_fail_lib",
+    srcs = ["greeter_idom_fail.js", "greeter_idom_fail_test.js"],
+    language = "ECMASCRIPT6_STRICT",
+    deps = [
+        ":greeter_idom_soy",
+        "//closure/library",
+        "//third_party/javascript/incremental_dom",
+    ],
+)
+
+closure_js_library(
     name = "greeter_proto_lib",
     srcs = ["greeter_proto.js"],
     deps = [
@@ -114,6 +126,18 @@ closure_js_test(
         "//closure/library",
         "//closure/library:testing",
     ],
+)
+
+closure_js_binary(
+    name = "greeter_idom_fail_bin",
+    language = "ECMASCRIPT5_STRICT",
+    deps = [
+        ":greeter_idom_fail_lib",
+        "//closure/library",
+        "//closure/library:testing",
+    ],
+    pedantic = True,
+    internal_expect_failure = True,
 )
 
 closure_js_test(

--- a/closure/templates/test/greeter_idom_fail.js
+++ b/closure/templates/test/greeter_idom_fail.js
@@ -1,0 +1,46 @@
+// Copyright 2016 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+goog.module('io.bazel.rules.closure.GreeterIdomFail');
+
+const idom = goog.require('incrementaldom');
+const greeter = goog.require('io.bazel.rules.closure.soy.greeter.incrementaldom');
+
+
+
+exports = class GreeterIdomFail {
+  /**
+   * Greeter page.
+   * @param {string} name Name of person to greet.
+   */
+  constructor(name) {
+    /**
+     * Name of person to greet.
+     * @private {string}
+     * @const
+     */
+    this.name_ = name;
+  }
+
+  /**
+   * Renders HTML greeting as document body.
+   */
+  greet() {
+    idom.patchInner(
+        /** @type {!Element} */ (goog.global.document.body),
+        greeter.greet,
+        // Missing required 'name' param
+        {});
+  }
+};

--- a/closure/templates/test/greeter_idom_fail_test.js
+++ b/closure/templates/test/greeter_idom_fail_test.js
@@ -1,0 +1,23 @@
+// Copyright 2016 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+goog.require('goog.module');
+goog.require('io.bazel.rules.closure.GreeterIdomFail');
+
+
+function testGreet() {
+  var GreeterIdomFail = goog.module.get('io.bazel.rules.closure.GreeterIdomFail');
+  var greeter = new GreeterIdomFail('Andy');
+  greeter.greet();
+}

--- a/third_party/javascript/incremental_dom/build.sh
+++ b/third_party/javascript/incremental_dom/build.sh
@@ -31,22 +31,23 @@ set -u
 tar xfz $1 --strip 1;
 
 echo "goog.module('incrementaldom');" > $2;
+echo "Object.defineProperty(exports, '__esModule', { value: true });" >> $2;
 
 cat src/util.js \
     src/node_data.js \
-    src/symbols.js \
-    src/attributes.js \
     src/nodes.js \
     src/notifications.js \
     src/context.js \
     src/assertions.js \
     src/dom_util.js \
     src/core.js \
+    src/symbols.js \
+    src/attributes.js \
     src/virtual_elements.js | \
     tr '\n' '\r' | \
     sed 's/export [^;]*;//g' | \
     sed 's/import [^;]*;//g' | \
-    sed "s/process.env.NODE_ENV/'undefined'/g" | \
+    sed "s/process.env.NODE_ENV !== 'production'/goog.DEBUG/g" | \
     sed 's/const elementOpen /const coreElementOpen /' | \
     sed 's/const elementClose /const coreElementClose /' | \
     sed 's/const text /const coreText /' | \


### PR DESCRIPTION
Add a target to ensure that missing required template @params result in a
compile time error. Without this bugfix (setting __esModule) in
incremental-dom-closure.js the compiler misses detection of required
parameters.