### PR TITLE
Deprecate externs attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ Please see the test directories within this project for concrete examples of usa
 
 ```python
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_library")
-closure_js_library(name, srcs, externs, data, deps, language, exports, suppress,
+closure_js_library(name, srcs, data, deps, language, exports, suppress,
                    convention, no_closure_library)
 ```
 
-Defines a set of JavaScript sources or externs.
+Defines a set of JavaScript sources.
 
 The purpose of this rule is to define an abstract graph of JavaScript sources.
 It must be used in conjunction with [closure_js_binary] to output a minified
@@ -167,15 +167,9 @@ This rule can be referenced as though it were the following:
   then convention states that the `_lib` suffix should be used.
 
 - **srcs:** (List of [labels]; optional) The list of `.js` source files that
-  represent this library. This attribute is required unless the `exports`
-  attribute is being defined. Files listed under this attribute must not use the
-  `@externs` annotation.
-
-- **externs:** (List of [labels]; optional) A list of `.js` files annotated
-  `@externs` at the top of the file. If this attribute is specified, `srcs` must
-  be empty. These files tell the Closure Compiler about the type signatures of
-  external libraries. Please note that the externs for web browsers are enabled
-  by default by the Closure Compiler.
+  represent this library. This can include files marked as `@externs` or
+  `@nocompile`. This attribute is required unless the `exports` attribute is
+  being defined.
 
 - **data:** (List of [labels]; optional) Runfiles directly referenced by JS
   sources in this rule. For example, if the JS generated injected an img tag
@@ -312,9 +306,9 @@ This rule can be referenced as though it were the following:
 - [filegroup]: `srcs` will be the .js and .js.map output files and `data` will
   contain those files in addition to all transitive JS sources and data.
 
-- [closure_js_library]: `srcs` will be the .js output file, `externs` will be
-  empty, `language` will be the output language, `deps` will be empty, `data`
-  will contain all transitive data, and `no_closure_library` will be `True`.
+- [closure_js_library]: `srcs` will be the .js output file, `language` will be
+  the output language, `deps` will be empty, `data` will contain all transitive
+  data, and `no_closure_library` will be `True`.
 
 ### Arguments
 
@@ -641,10 +635,10 @@ This rule can be referenced as though it were the following:
 - [filegroup]: `srcs` will be the generated JS output files and `data` will
   contain all transitive JS sources and data.
 
-- [closure_js_library]: `srcs` will be the generated JS output files, `externs`
-  will be empty, `data` will contain the transitive data, `language` will be
-  `ECMASCRIPT5_STRICT`, `deps` will contain necessary libraries, and
-  `no_closure_library` will be `False`.
+- [closure_js_library]: `srcs` will be the generated JS output files, `data`
+  will contain the transitive data, `language` will be `ECMASCRIPT5_STRICT`,
+  `deps` will contain necessary libraries, and `no_closure_library` will be
+  `False`.
 
 ### Arguments
 
@@ -793,11 +787,10 @@ This rule can be referenced as though it were the following:
 - [filegroup]: `srcs` will be the generated JS output files and `data` will
   contain all transitive CSS/GSS sources and data.
 
-- [closure_js_library]: `srcs` is empty, `externs` is empty, `data` is the
-  transitive CSS sources and data, `language` is `ANY`, and `no_closure_library`
-  is `True`. However the closure\_css\_library rule does pass special
-  information along when used as a dep in closure\_js\_library. See its
-  documentation to learn more.
+- [closure_js_library]: `srcs` is empty, `data` is the transitive CSS sources
+  and data, `language` is `ANY`, and `no_closure_library` is `True`. However the
+  closure\_css\_library rule does pass special information along when used as a
+  dep in closure\_js\_library. See its documentation to learn more.
 
 ### Arguments
 
@@ -973,9 +966,9 @@ This rule can be referenced as though it were the following:
 - [filegroup]: `srcs` will be empty and `data` will contain all transitive JS
   sources and data.
 
-- [closure_js_library]: `srcs` will be the generated JS output files, `externs`
-  will be empty, `data` will contain the transitive data, `language` will be
-  `ECMASCRIPT5_STRICT`, and `deps` will contain necessary libraries.
+- [closure_js_library]: `srcs` will be the generated JS output files, `data`
+  will contain the transitive data, `language` will be `ECMASCRIPT5_STRICT`, and
+  `deps` will contain necessary libraries.
 
 ### Arguments
 

--- a/closure/compiler/closure_js_binary.bzl
+++ b/closure/compiler/closure_js_binary.bzl
@@ -55,7 +55,7 @@ _SUPPRESS_THINGS_JSCHECKER_ALREADY_DID = [
 def _impl(ctx):
   if not ctx.attr.deps:
     fail("closure_js_binary rules can not have an empty 'deps' list")
-  srcs, externs, tdata = collect_transitive_js_srcs(ctx)
+  srcs, tdata = collect_transitive_js_srcs(ctx)
   if not srcs:
     fail("There are no source files in the transitive closure")
   _validate_css_graph(ctx)
@@ -130,11 +130,7 @@ def _impl(ctx):
   for config in ctx.files.conformance:
     args.append("--conformance_configs")
     args.append(config.path)
-  for extern in externs:
-    args.append("--externs")
-    args.append(extern.path)
   for src in srcs:
-    args.append("--js")
     args.append(src.path)
     if src.owner == BASE_JS:
       if not ctx.attr.debug:
@@ -152,8 +148,6 @@ def _impl(ctx):
   inputs = []
   for src in srcs:
     inputs.append(src)
-  for extern in externs:
-    inputs.append(extern)
   inputs.extend(ctx.files.conformance)
 
   # These rule-provided.txt files will not be used by JsCompiler. But we list
@@ -173,8 +167,7 @@ def _impl(ctx):
       mnemonic="Closure",
       execution_requirements={"supports-workers": "1"},
       progress_message="Compiling %d JavaScript files to %s" % (
-          len(srcs) + len(externs),
-          ctx.outputs.out.short_path))
+          len(srcs), ctx.outputs.out.short_path))
 
   # this is necessary for closure_js_binary to behave like closure_js_library
   ctx.file_action(output=ctx.outputs.provided, content="")
@@ -185,7 +178,6 @@ def _impl(ctx):
                 js_provided=ctx.outputs.provided,
                 required_css_labels=set(order="compile"),
                 transitive_js_srcs=set([ctx.outputs.out], order="compile"),
-                transitive_js_externs=set(order="compile"),
                 transitive_data=tdata + ctx.files.data,
                 runfiles=ctx.runfiles(files=list(files) + ctx.files.data,
                                       transitive_files=srcs + tdata))

--- a/closure/compiler/closure_js_deps.bzl
+++ b/closure/compiler/closure_js_deps.bzl
@@ -23,7 +23,7 @@ load("//closure/private:defs.bzl",
      "long_path")
 
 def _impl(ctx):
-  srcs, _, tdata = collect_transitive_js_srcs(ctx)
+  srcs, tdata = collect_transitive_js_srcs(ctx)
   basejs = ctx.file._closure_library_base
   closure_root = _dirname(long_path(ctx, basejs))
   closure_rel = '/'.join(['..' for _ in range(len(closure_root.split('/')))])

--- a/closure/compiler/test/BUILD
+++ b/closure/compiler/test/BUILD
@@ -205,3 +205,48 @@ file_test(
     content = "-- console.log(\"hello world\");\n",
     file = "hello_output_wrapper_dash_dash_space_bin.js",
 )
+
+################################################################################
+# External definitions work
+
+closure_js_library(
+    name = "extern_lib",
+    srcs = ["extern.js"],
+)
+
+closure_js_library(
+    name = "extern_invoke_lib",
+    srcs = ["extern_invoke.js"],
+    deps = [":extern_lib"],
+)
+
+closure_js_binary(
+    name = "extern_bin",
+    pedantic = True,
+    deps = [":extern_invoke_lib"],
+)
+
+file_test(
+    name = "externFile_namesDidntCollapse",
+    content = "omg.im_an_extern(\"hello\");\n",
+    file = "extern_bin.js",
+)
+
+closure_js_library(
+    name = "extern_invoke_bad_lib",
+    srcs = ["extern_invoke_bad.js"],
+    deps = [":extern_lib"],
+)
+
+closure_js_binary(
+    name = "extern_bad_bin",
+    internal_expect_failure = True,
+    pedantic = True,
+    deps = [":extern_invoke_bad_lib"],
+)
+
+file_test(
+    name = "externTypeError_failsToCompile",
+    file = "extern_bad_bin-stderr.txt",
+    regexp = "actual parameter 1 of omg.im_an_extern does not match formal parameter",
+)

--- a/closure/compiler/test/closure_js_deps/BUILD
+++ b/closure/compiler/test/closure_js_deps/BUILD
@@ -38,7 +38,7 @@ load("//closure:defs.bzl", "closure_js_library")
 
 closure_js_library(
     name = "external_library",
-    externs = ["external_library.js"],
+    srcs = ["external_library.js"],
 )
 
 closure_js_library(

--- a/closure/compiler/test/closure_js_deps/hyperion2_bin_runfiles_test.sh
+++ b/closure/compiler/test/closure_js_deps/hyperion2_bin_runfiles_test.sh
@@ -27,9 +27,6 @@ set -ex
 [[ -e closure/compiler/test/closure_js_deps/hyperion.js ]]
 [[ -e closure/compiler/test/closure_js_deps/hyperion2.js ]]
 
-# none of the externs (same behavior as closure_js_library)
-[[ ! -e closure/compiler/test/closure_js_deps/external_library.js ]]
-
 # none of the internal-only files we generate (same as closure_js_library)
 [[ ! -e closure/compiler/test/closure_js_deps/hyperion_lib-provided.txt ]]
 [[ ! -e closure/compiler/test/closure_js_deps/hyperion_lib-stderr.txt ]]

--- a/closure/compiler/test/closure_js_deps/hyperion2_lib_runfiles_test.sh
+++ b/closure/compiler/test/closure_js_deps/hyperion2_lib_runfiles_test.sh
@@ -31,9 +31,6 @@ set -ex
 # transitive data
 [[ -e closure/compiler/test/closure_js_deps/data1.txt ]]
 
-# no externs sources, since they're only useful to the compiler
-[[ ! -e closure/compiler/test/closure_js_deps/external_library.js ]]
-
 # none of those internal-only files we generate
 [[ ! -e closure/compiler/test/closure_js_deps/hyperion_lib-provided.txt ]]
 [[ ! -e closure/compiler/test/closure_js_deps/hyperion_lib-stderr.txt ]]

--- a/closure/compiler/test/extern.js
+++ b/closure/compiler/test/extern.js
@@ -1,0 +1,26 @@
+// Copyright 2016 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Example external definition.
+ * @externs
+ */
+
+var omg = {};
+
+
+/**
+ * @param {string} a
+ */
+omg.im_an_extern = function(a) {};

--- a/closure/compiler/test/extern_invoke.js
+++ b/closure/compiler/test/extern_invoke.js
@@ -1,0 +1,15 @@
+// Copyright 2016 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+omg.im_an_extern('hello');

--- a/closure/compiler/test/extern_invoke_bad.js
+++ b/closure/compiler/test/extern_invoke_bad.js
@@ -1,0 +1,15 @@
+// Copyright 2016 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+omg.im_an_extern(666);

--- a/closure/compiler/test/strict_dependency_checking/BUILD
+++ b/closure/compiler/test/strict_dependency_checking/BUILD
@@ -56,7 +56,6 @@ rule_test(
         "js_language": "^\"ECMASCRIPT5_STRICT\"$",
         "js_exports": "^\\[\\]$",
         "transitive_js_srcs": "/a.js\\]",
-        "transitive_js_externs": "",
     },
     rule = ":a",
 )
@@ -67,7 +66,6 @@ rule_test(
         "js_language": "^\"ECMASCRIPT5_STRICT\"$",
         "js_exports": "^\\[\\]$",
         "transitive_js_srcs": "/a\\.js.*/b\\.js\\]",
-        "transitive_js_externs": "",
     },
     rule = ":b",
 )
@@ -78,7 +76,6 @@ rule_test(
         "js_language": "^\"ECMASCRIPT5_STRICT\"$",
         "js_exports": "^\\[\\]$",
         "transitive_js_srcs": "/a\\.js.*/b\\.js.*/c\\.js\\]",
-        "transitive_js_externs": "",
     },
     rule = ":c",
 )
@@ -89,7 +86,6 @@ rule_test(
         "js_language": "^\"ECMASCRIPT5_STRICT\"$",
         "js_exports": "^\\[\\]$",
         "transitive_js_srcs": "/t\\.js\\]",
-        "transitive_js_externs": "",
     },
     rule = ":t",
 )

--- a/closure/private/defs.bzl
+++ b/closure/private/defs.bzl
@@ -54,7 +54,6 @@ JS_DEPS_PROVIDERS = [
     "js_provided",
     "required_css_labels",
     "transitive_js_srcs",
-    "transitive_js_externs",
 ]
 
 JS_DEPS_ATTR = attr.label_list(allow_files=False, providers=JS_DEPS_PROVIDERS)
@@ -74,7 +73,6 @@ CLOSURE_LIBRARY_DEPS_ATTR = attr.label(
 
 def collect_transitive_js_srcs(ctx):
   srcs = set(order="compile")
-  externs = set(order="compile")
   data = set(order="compile")
   if hasattr(ctx.attr, 'css'):
     if ctx.attr.css:
@@ -90,13 +88,11 @@ def collect_transitive_js_srcs(ctx):
              ctx.file._closure_library_deps]
   for dep in ctx.attr.deps:
     srcs += dep.transitive_js_srcs
-    externs += dep.transitive_js_externs
     data += dep.transitive_data
     for edep in dep.js_exports:
       srcs += edep.transitive_js_srcs
-      externs += edep.transitive_js_externs
       data += edep.transitive_data
-  return srcs, externs, data
+  return srcs, data
 
 def collect_transitive_css_labels(ctx):
   result = set(order="compile")

--- a/closure/stylesheets/closure_css_library.bzl
+++ b/closure/stylesheets/closure_css_library.bzl
@@ -36,7 +36,6 @@ def _impl(ctx):
                 js_exports=[],
                 js_provided=ctx.outputs.provided,
                 transitive_js_srcs=set(),
-                transitive_js_externs=set(),
                 css_orientation=ctx.attr.orientation,
                 required_css_labels=set(),
                 transitive_css_labels=collect_transitive_css_labels(ctx),

--- a/closure/testing/BUILD
+++ b/closure/testing/BUILD
@@ -19,7 +19,7 @@ package(
 
 licenses(["notice"])  # Apache 2.0
 
-load("//closure:defs.bzl", "closure_js_library")
+load("//closure:defs.bzl", "closure_js_binary", "closure_js_library")
 
 exports_files(["empty.html"])
 
@@ -34,4 +34,11 @@ closure_js_library(
     srcs = ["phantomjs_harness.js"],
     no_closure_library = True,
     deps = ["//closure/testing/externs:phantomjs"],
+)
+
+closure_js_binary(
+    name = "phantomjs_harness_bin",
+    defs = ["--env=CUSTOM"],
+    pedantic = True,
+    deps = [":phantomjs_harness"],
 )

--- a/closure/testing/externs/BUILD
+++ b/closure/testing/externs/BUILD
@@ -20,5 +20,7 @@ load("//closure:defs.bzl", "closure_js_library")
 
 closure_js_library(
     name = "phantomjs",
-    externs = ["phantom.js"],
+    srcs = ["phantom.js"],
+    language = "ECMASCRIPT6_STRICT",
+    no_closure_library = True,
 )

--- a/closure/testing/externs/phantom.js
+++ b/closure/testing/externs/phantom.js
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 /**
- * @fileoverview PhantomJS API definitions. We're only defining the parts of
- *     the API we plan on using. This file is necessary in order to have 100%
- *     strict type safety in {@code testrunner.js}.
+ * @fileoverview External definition for subset of PhantomJS API.
  * @externs
  * @see http://phantomjs.org/api/
  */
@@ -24,40 +22,34 @@
 /**
  * Fake namespace for PhantomJS types.
  */
-var phantomjs = {};
-
+const phantomjs = {};
 
 
 /**
- * @constructor
- * @final
+ * @record
  * @see https://github.com/ariya/phantomjs/blob/master/examples/stdin-stdout-stderr.js
  */
-phantomjs.File = function() {};
+phantomjs.File = class {
+
+  /**
+   * @param {string} text
+   * @const
+   */
+  write(text) {}
+
+  /**
+   * @param {string} text
+   * @const
+   */
+  writeLine(text) {}
+};
 
 
 /**
- * @param {string} text
- * @const
- */
-phantomjs.File.prototype.write = function(text) {};
-
-
-/**
- * @param {string} text
- * @const
- */
-phantomjs.File.prototype.writeLine = function(text) {};
-
-
-
-/**
- * @constructor
- * @final
+ * @record
  * @see http://phantomjs.org/api/system/
  */
-phantomjs.System = function() {};
-
+phantomjs.System = class {};
 
 /**
  * @type {!Array<string>}
@@ -65,13 +57,11 @@ phantomjs.System = function() {};
  */
 phantomjs.System.prototype.args;
 
-
 /**
  * @type {!phantomjs.File}
  * @const
  */
 phantomjs.System.prototype.stdout;
-
 
 /**
  * @type {!phantomjs.File}
@@ -80,50 +70,45 @@ phantomjs.System.prototype.stdout;
 phantomjs.System.prototype.stderr;
 
 
-
 /**
- * @constructor
- * @final
+ * @record
  * @see http://phantomjs.org/api/fs/
  */
-phantomjs.FileSystem = function() {};
+phantomjs.FileSystem = class {
+
+  /**
+   * @param {string} path
+   * @return {boolean}
+   * @const
+   */
+  exists(path) {}
+
+  /**
+   * @param {string} path
+   * @return {string}
+   * @const
+   */
+  read(path) {}
+};
 
 
 /**
- * @param {string} path
- * @return {boolean}
+ * @record
  */
-phantomjs.FileSystem.prototype.exists = function(path) {};
+phantomjs.WebPage = class {
+
+  /**
+   * @return {!phantomjs.Page}
+   * @const
+   */
+  create() {}
+};
 
 
 /**
- * @param {string} path
- * @return {string}
+ * @record
  */
-phantomjs.FileSystem.prototype.read = function(path) {};
-
-
-
-/**
- * @constructor
- * @final
- */
-phantomjs.WebPage = function() {};
-
-
-/**
- * @return {!phantomjs.Page}
- */
-phantomjs.WebPage.prototype.create = function() {};
-
-
-
-/**
- * @constructor
- * @final
- */
-phantomjs.PageSettings = function() {};
-
+phantomjs.PageSettings = class {};
 
 /**
  * @type {number}
@@ -131,31 +116,114 @@ phantomjs.PageSettings = function() {};
 phantomjs.PageSettings.prototype.resourceTimeout;
 
 
+/**
+ * @record
+ */
+phantomjs.StackFrame = class {};
 
 /**
- * @constructor
- * @final
+ * @type {string}
+ * @const
  */
-phantomjs.Page = function() {};
+phantomjs.StackFrame.prototype.file;
+
+/**
+ * @type {number}
+ * @const
+ */
+phantomjs.StackFrame.prototype.line;
+
+/**
+ * @type {string}
+ * @const
+ */
+phantomjs.StackFrame.prototype.function;
 
 
 /**
- * @param {string} url
- * @param {function(string)=} opt_callback
+ * @typedef {Array<!phantomjs.StackFrame>}
  */
-phantomjs.Page.prototype.open = function(url, opt_callback) {};
-
-
-phantomjs.Page.prototype.close = function() {};
+phantomjs.StackTrace;
 
 
 /**
- * @param {function(): T} callback
- * @return {T}
- * @template T
+ * @enum {string}
+ * @const
  */
-phantomjs.Page.prototype.evaluate = function(callback) {};
+phantomjs.LoadStatus = {
+  SUCCESS: 'success',
+  FAIL: 'fail',
+};
 
+
+/**
+ * @record
+ */
+phantomjs.Page = class {
+
+  /**
+   * @param {string} url
+   * @param {function(string)=} opt_callback
+   * @const
+   */
+  open(url, opt_callback) {}
+
+  /**
+   * @const
+   */
+  close() {}
+
+  /**
+   * @param {function(): T} callback
+   * @return {T}
+   * @template T
+   * @const
+   */
+  evaluate(callback) {}
+
+  /**
+   * @param {string} message
+   */
+  onAlert(message) {}
+
+  /**
+   * @param {?} data
+   */
+  onCallback(data) {}
+
+  /**
+   * @param {!phantomjs.Page} data
+   */
+  onClosing(data) {}
+
+  /**
+   * @param {string} message
+   * @return {boolean}
+   */
+  onConfirm(message) {}
+
+  /**
+   * @param {string} message
+   * @param {?string} line
+   * @param {?string} source
+   */
+  onConsoleMessage(message, line, source) {}
+
+  /**
+   * @param {string} message
+   * @param {!phantomjs.StackTrace} trace
+   */
+  onError(message, trace) {}
+
+  onInitialized() {}
+
+  /**
+   * @param {phantomjs.LoadStatus} status
+   */
+  onLoadFinished(status) {}
+
+  onLoadStarted() {}
+};
 
 /**
  * @type {!phantomjs.PageSettings}
@@ -164,37 +232,33 @@ phantomjs.Page.prototype.evaluate = function(callback) {};
 phantomjs.Page.prototype.settings;
 
 
-
 /**
- * @constructor
- * @final
+ * @record
  * @see http://phantomjs.org/api/webserver/
  */
-phantomjs.Server = function() {};
+phantomjs.Server = class {
 
+  /**
+   * @param {number|string} port
+   * @param {function(!phantomjs.Server.Request,
+   *                  !phantomjs.Server.Response)} callback
+   * @const
+   */
+  listen(port, callback) {}
+};
 
 /**
  * @type {number}
+ * @const
  */
 phantomjs.Server.prototype.port;
 
 
 /**
- * @param {(number|string)} port
- * @param {function(!phantomjs.Server.Request,
- *                  !phantomjs.Server.Response)} callback
- */
-phantomjs.Server.prototype.listen = function(port, callback) {};
-
-
-
-/**
- * @constructor
- * @final
+ * @record
  * @see http://phantomjs.org/api/webserver/method/listen.html
  */
-phantomjs.Server.Request = function() {};
-
+phantomjs.Server.Request = class {};
 
 /**
  * @type {string}
@@ -203,76 +267,76 @@ phantomjs.Server.Request = function() {};
 phantomjs.Server.Request.prototype.url;
 
 
-
 /**
- * @constructor
- * @final
+ * @record
  * @see http://phantomjs.org/api/webserver/method/listen.html
  */
-phantomjs.Server.Response = function() {};
+phantomjs.Server.Response = class {
+
+  /**
+   * @param {string} encoding
+   * @const
+   */
+  setEncoding(encoding) {}
+
+  /**
+   * @param {number} statusCode
+   * @param {!Object<string, string>=} opt_headers
+   * @const
+   */
+  writeHead(statusCode, opt_headers) {}
+
+  /**
+   * @param {string} data
+   * @const
+   */
+  write(data) {}
+
+  /**
+   * @const
+   */
+  close() {}
+
+  /**
+   * @const
+   */
+  closeGracefully() {}
+};
 
 
 /**
- * @param {string} encoding
- */
-phantomjs.Server.Response.prototype.setEncoding = function(encoding) {};
-
-
-/**
- * @param {number} statusCode
- * @param {!Object<string, string>=} opt_headers
- */
-phantomjs.Server.Response.prototype.writeHead =
-    function(statusCode, opt_headers) {};
-
-
-/**
- * @param {string} data
- */
-phantomjs.Server.Response.prototype.write = function(data) {};
-
-
-phantomjs.Server.Response.prototype.close = function() {};
-
-
-phantomjs.Server.Response.prototype.closeGracefully = function() {};
-
-
-
-/**
- * @constructor
- * @final
+ * @record
  * @see http://phantomjs.org/api/webserver/
  */
-phantomjs.WebServer = function() {};
+phantomjs.WebServer = class {
+
+  /**
+   * @return {!phantomjs.Server}
+   * @const
+   */
+  create() {}
+};
 
 
 /**
- * @return {!phantomjs.Server}
- */
-phantomjs.WebServer.prototype.create = function() {};
-
-
-
-/**
- * @constructor
- * @final
+ * @record
  * @see http://phantomjs.org/api/phantom/
  */
-phantomjs.Phantom = function() {};
+phantomjs.Phantom = class {
 
-
-/**
- * @param {number=} opt_status
- */
-phantomjs.Phantom.prototype.exit = function(opt_status) {};
+  /**
+   * @param {number=} opt_status
+   * @const
+   */
+  exit(opt_status) {}
+};
 
 
 /**
  * @type {!phantomjs.Phantom}
  * @const
  */
-var phantom;
+let phantom;
 
 
 /**

--- a/closure/testing/phantomjs_harness.js
+++ b/closure/testing/phantomjs_harness.js
@@ -31,7 +31,6 @@ var /** !phantomjs.System */ system = require('system');
 
 /**
  * Location of virtual test page.
- * @type {string}
  * @const
  */
 var VIRTUAL_PAGE = '/index.html';
@@ -39,7 +38,6 @@ var VIRTUAL_PAGE = '/index.html';
 
 /**
  * Path under which runfiles are served.
- * @type {string}
  * @const
  */
 var RUNFILES_PREFIX = '/filez/';
@@ -190,9 +188,7 @@ function onAlert(message) {
 /**
  * Callback when headless web page throws an error.
  * @param {string} message
- * @param {!Array<{file: string,
- *                 line: number,
- *                 function: string}>} trace
+ * @param {!phantomjs.StackTrace} trace
  */
 function onError(message, trace) {
   system.stderr.writeLine(message);

--- a/closure/testing/phantomjs_test.bzl
+++ b/closure/testing/phantomjs_test.bzl
@@ -84,7 +84,7 @@ _phantomjs_test = rule(
         "harness": attr.label(
             allow_files=False,
             providers=JS_DEPS_PROVIDERS,
-            default=Label("//closure/testing:phantomjs_harness")),
+            default=Label("//closure/testing:phantomjs_harness_bin")),
         "runner": attr.label(
             allow_files=False,
             providers=JS_DEPS_PROVIDERS,

--- a/java/com/google/javascript/jscomp/JsChecker.java
+++ b/java/com/google/javascript/jscomp/JsChecker.java
@@ -118,13 +118,8 @@ public final class JsChecker {
 
   @Option(
       name = "--src",
-      usage = "JavaScript source files, sans externs.")
+      usage = "JavaScript source and externs files.")
   private List<String> sources = new ArrayList<>();
-
-  @Option(
-      name = "--extern",
-      usage = "JavaScript @externs source files.")
-  private List<String> externs = new ArrayList<>();
 
   @Option(
       name = "--dep",
@@ -286,7 +281,7 @@ public final class JsChecker {
     // run the compiler
     compiler.setPassConfig(new JsCheckerPassConfig(state, options));
     compiler.disableThreads();
-    compiler.compile(getSourceFiles(externs), getSourceFiles(sources), options);
+    compiler.compile(ImmutableList.<SourceFile>of(), getSourceFiles(sources), options);
 
     // make sure all suppress codes were actually suppressed
     Set<String> useless = Sets.difference(ImmutableSet.copyOf(suppress), actuallySuppressed);


### PR DESCRIPTION
This change deprecates the `externs` attribute of `closure_js_library`, removes all externs graph code. It also adds tests for externs functionality, and improves the code health of the externs we use in our codebase.

It's been possible for several years to list `@externs` files in the `srcs` attribute. So having a separate graph for externs doesn't really offer any advantages.