### PR TITLE
Add osx in travis build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,32 @@
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-4.8
-      - g++-4.8
-      - wget
-      # Package list from http://bazel.io/docs/install.html
-      - pkg-config
-      - zip
-      - unzip
-      - zlib1g-dev
+# trusty beta image has jdk8, gcc4.8.4
+dist: trusty
+sudo: required
+# xcode8 has jdk8
+osx_image: xcode8
+# Not technically required but suppresses 'Ruby' in Job status message.
+language: java
 
-jdk:
-  - oraclejdk8
+os:
+  - linux
+  - osx
 
 env:
-  - V=HEAD URL_BASE=http://ci.bazel.io/job/Bazel/JAVA_VERSION=1.8,PLATFORM_NAME=linux-x86_64/lastSuccessfulBuild/artifact/output/ci/ URL="$URL_BASE`wget -qO- $URL_BASE | grep -oP 'bazel-.*?-installer.sh' | uniq`" FLAGS='--worker_verbose --strategy=Javac=worker --strategy=Closure=worker'
-  - V=0.3.2 URL=http://bazel-mirror.storage.googleapis.com/github.com/bazelbuild/bazel/releases/download/0.3.2/bazel-0.3.2-installer-linux-x86_64.sh FLAGS='--worker_verbose --strategy=Javac=worker --strategy=Closure=worker'
-  - V=0.3.1 URL=http://bazel-mirror.storage.googleapis.com/github.com/bazelbuild/bazel/releases/download/0.3.1/bazel-0.3.1-installer-linux-x86_64.sh FLAGS='--worker_verbose --strategy=Javac=worker --strategy=Closure=worker'
+  - V=HEAD
+  - V=0.3.2
+  - V=0.3.1
 
 before_install:
-  - sudo sysctl kernel.unprivileged_userns_clone=1
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sysctl kernel.unprivileged_userns_clone=1; fi
+  - OS=linux
+  - ARCH=x86_64
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then OS=darwin; fi
+  - GH_BASE="https://github.com/bazelbuild/bazel/releases/download/$V"
+  - GH_ARTIFACT="bazel-$V-installer-$OS-$ARCH.sh"
+  - CI_BASE="http://ci.bazel.io/job/Bazel/JAVA_VERSION=1.8,PLATFORM_NAME=$OS-$ARCH/lastSuccessfulBuild/artifact/output/ci"
+  - CI_ARTIFACT="bazel--installer.sh"
+  - URL="$GH_BASE/$GH_ARTIFACT"
+  - if [[ "$V" == "HEAD" ]]; then URL="$CI_BASE/$CI_ARTIFACT"; fi
+  - echo $URL
   - wget -O install.sh $URL
   - chmod +x install.sh
   - ./install.sh --user
@@ -42,7 +47,9 @@ script:
       --spawn_strategy=standalone \
       --genrule_strategy=standalone \
       --local_resources=400,2,1.0 \
-      $FLAGS
+      --worker_verbose \
+      --strategy=Javac=worker \
+      --strategy=Closure=worker
 
 notifications:
   email: false


### PR DESCRIPTION
This is a variant of the travis file recently merged in rules_go.  `sudo=required` selects the *trusty beta* image that has jdk8.  It looks a bit off-putting, but I don't think it undermines the quality of the outcome.  If you don't use this, one has to explicity name `jdk = oraclejkd8`. That however conflicts with os=osx and forces one into a `matrix.include` pattern (which has it's own set of issues).