### PR TITLE
Resolve correct artifact for HEAD and release candidate.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ before_install:
   - CI_BASE="http://ci.bazel.io/job/Bazel/JAVA_VERSION=1.8,PLATFORM_NAME=$OS-$ARCH/lastSuccessfulBuild/artifact/output/ci"
   - CI_ARTIFACT="bazel--installer.sh"
   - URL="$GH_BASE/$GH_ARTIFACT"
+  - if [[ "$V" == "HEAD" && "$OS" == "linux" ]]; then CI_ARTIFACT="`wget -qO- $CI_BASE | grep -oP 'bazel-.*?-installer.sh' | uniq`"; fi
+  - if [[ "$V" == "HEAD" && "$OS" == "osx" ]];   then CI_ARTIFACT="`wget -qO- $CI_BASE | pcregrep -o 'bazel-.*?-installer.sh' | uniq`"; fi
   - if [[ "$V" == "HEAD" ]]; then URL="$CI_BASE/$CI_ARTIFACT"; fi
   - echo $URL
   - wget -O install.sh $URL

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,3 +12,4 @@
 Justine Tunney <jart@google.com>
 Kamil Jiwa <kjiwa@google.com>
 Andy Hochhaus <andy@hochhaus.us>
+Paul Johnston <pcj@pubref.org>


### PR DESCRIPTION
Once ci.bazel.io put out a release candidate the initial osx travis script broke, demonstrating the importance of parsing the artifact name from the HTML page.  This change puts that logic back in (credit to @hochhaus) with pcregrep tweak for osx.  