### PR TITLE
Update proto rules to work with execroot rearrangement

### DIFF
--- a/closure/protobuf/closure_js_proto_library.bzl
+++ b/closure/protobuf/closure_js_proto_library.bzl
@@ -17,6 +17,16 @@
 
 load("//closure/compiler:closure_js_library.bzl", "closure_js_library")
 
+def _collect_includes(srcs):
+  includes = ["."]
+  for src in srcs:
+    include = ""
+    if src.startswith("@"):
+      include = Label(src).workspace_root
+    if include and not include in includes:
+      includes += [include]
+  return includes
+
 def closure_js_proto_library(
     name,
     srcs,
@@ -37,6 +47,8 @@ def closure_js_proto_library(
     js_out_options += ["binary"]
   if import_style:
     js_out_options += ["import_style=%s" % import_style]
+
+  cmd += ["-I%s" % i for i in _collect_includes(srcs)]
   cmd += ["--js_out=%s:$(@D)" % ",".join(js_out_options)]
   cmd += ["--descriptor_set_out=$(@D)/%s.descriptor" % name]
   cmd += ["$(locations " + src + ")" for src in srcs]


### PR DESCRIPTION
When https://github.com/bazelbuild/bazel/issues/1681 is submitted,
external repositories' proto sources will no longer be under the
execution root, they will be under ../repo_name. protoc needs to know
which directories to look under, so this updates the genrule to include
all repository paths in the protoc's search.

This change should be backwards and forwards compatible, since protoc
doesn't care if it gets extra search paths.