### PR TITLE
Update Java proto library and js_module_root refs to refer to sibling…

### DIFF
--- a/closure/private/gensrcjar.sh
+++ b/closure/private/gensrcjar.sh
@@ -20,7 +20,7 @@
 # We use environment variables instead of positional arguments or flags for
 # clarity in the caller .bzl file and for simplicity of processing.  There is no
 # need to implement a full-blown argument parser for this simple script.
-INPUT_VARS="JAR OUTPUT PREPROCESSOR PROTO_COMPILER SOURCE"
+INPUT_VARS="JAR OUTPUT PREPROCESSOR PROTO_COMPILER SOURCE INCLUDES"
 
 # Now set defaults for optional input variables.
 : "${PREPROCESSOR:=cat}"
@@ -68,11 +68,11 @@ main() {
       || err "Preprocessor ${PREPROCESSOR} failed"
 
   if [ -n "${GRPC_JAVA_PLUGIN}" ]; then
-    "${PROTO_COMPILER}" --plugin=protoc-gen-grpc="${GRPC_JAVA_PLUGIN}" \
+    "${PROTO_COMPILER}" --plugin=protoc-gen-grpc="${GRPC_JAVA_PLUGIN}" "${INCLUDES}" \
         --grpc_out="${proto_output}" --java_out="${proto_output}" "${processed_source}" \
         || err "proto_compiler failed"
   else
-    "${PROTO_COMPILER}" --java_out="${proto_output}" "${processed_source}" \
+    "${PROTO_COMPILER}" "${INCLUDES}" --java_out="${proto_output}" "${processed_source}" \
         || err "proto_compiler failed"
   fi
   find "${proto_output}" -exec touch -t "${TIMESTAMP}" '{}' \; \

--- a/closure/private/java_proto_library.bzl
+++ b/closure/private/java_proto_library.bzl
@@ -13,15 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 def _impl(ctx):
   out = ctx.outputs.srcjar
+  includes = ["-I."]
+  if ctx.attr.src.label.workspace_root:
+    includes += "-I%s" % ctx.attr.src.label.workspace_root
   ctx.action(
       command=' '.join([
           "JAR='%s'" % ctx.executable._jar.path,
           "OUTPUT='%s'" % out.path,
           "PROTO_COMPILER='%s'" % ctx.executable._proto_compiler.path,
           "SOURCE='%s'" % ctx.file.src.path,
+          "INCLUDES='%s'" % ' '.join(includes),
           ctx.executable._gensrcjar.path,
       ]),
       inputs=([ctx.file.src] + ctx.files._gensrcjar + ctx.files._jar +


### PR DESCRIPTION
… directories

This makes the js_module_root argument refer to the proper execution
root directory regardless of bazel version used.  Prep for https://github.com/bazelbuild/bazel/issues/1681.

Manually tested with old & new bazel versions.