### PR TITLE
Make rule tests compatible with the new string representations in Skylark

### DIFF
--- a/closure/compiler/test/strict_dependency_checking/BUILD
+++ b/closure/compiler/test/strict_dependency_checking/BUILD
@@ -52,25 +52,25 @@ closure_js_library(
 
 rule_test(
     name = "a_rule_test",
-    provides = {"closure_js_library.srcs": "/a.js\\]"},
+    provides = {"closure_js_library.srcs": "/a.js>\\?\\]"},
     rule = ":a",
 )
 
 rule_test(
     name = "b_rule_test",
-    provides = {"closure_js_library.srcs": "/a\\.js.*/b\\.js\\]"},
+    provides = {"closure_js_library.srcs": "/a\\.js.*/b\\.js>\\?\\]"},
     rule = ":b",
 )
 
 rule_test(
     name = "c_rule_test",
-    provides = {"closure_js_library.srcs": "/a\\.js.*/b\\.js.*/c\\.js\\]"},
+    provides = {"closure_js_library.srcs": "/a\\.js.*/b\\.js.*/c\\.js>\\?\\]"},
     rule = ":c",
 )
 
 rule_test(
     name = "t_rule_test",
-    provides = {"closure_js_library.srcs": "/t\\.js\\]"},
+    provides = {"closure_js_library.srcs": "/t\\.js>\\?\\]"},
     rule = ":t",
 )
 


### PR DESCRIPTION
In the future string representations of file object will be different and it will look like `<generated file path/to/file.txt>`, therefore the tests have been changed to check for this optional additional angular bracket.