### PR TITLE
Use module resoltion NODE by default.

### DIFF
--- a/java/com/google/javascript/jscomp/JsCompilerRunner.java
+++ b/java/com/google/javascript/jscomp/JsCompilerRunner.java
@@ -57,7 +57,7 @@ final class JsCompilerRunner extends CommandLineRunner {
     CompilerOptions options = super.createOptions();
     options.setExportTestFunctions(exportTestFunctions);
     options.addWarningsGuard(warnings);
-    options.setModuleResolutionMode(ModuleLoader.ResolutionMode.BROWSER);
+    options.setModuleResolutionMode(ModuleLoader.ResolutionMode.NODE);
     return options;
   }
 }


### PR DESCRIPTION
Module resolution BROWSER appears to import a subset of the files supported by NODE
module resolution. The only difference being that when .js suffixes can be left off
of import statements and that non absolute/relative import statements will be imported
from a node_modules directory.