### PR TITLE
make @com_google_protobuf_java a proper external repository.

### DIFF
--- a/closure/private/java_proto_library.bzl
+++ b/closure/private/java_proto_library.bzl
@@ -73,7 +73,7 @@ def java_proto_library(name, src, testonly=None, visibility=None, **kwargs):
   native.java_library(
       name = name,
       srcs = [":%s_srcjar" % name],
-      deps = ["@com_google_protobuf_java"],
+      deps = ["@com_google_protobuf_java//:protobuf_java"],
       javacopts = ["-Xlint:-rawtypes"],
       testonly = testonly,
       visibility = visibility,

--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -437,7 +437,7 @@ def com_google_common_html_types():
           "@com_google_errorprone_error_prone_annotations",
           "@com_google_guava",
           "@com_google_jsinterop_annotations",
-          "@com_google_protobuf_java",
+          "@com_google_protobuf_java//:protobuf_java",
           "@javax_annotation_jsr250_api",
       ],
   )
@@ -625,7 +625,7 @@ def com_google_javascript_closure_compiler():
           "@com_google_code_gson",
           "@com_google_guava",
           "@com_google_code_findbugs_jsr305",
-          "@com_google_protobuf_java",
+          "@com_google_protobuf_java//:protobuf_java",
       ],
       extra_build_file_content = "\n".join([
           "java_binary(",
@@ -682,14 +682,14 @@ def com_google_jsinterop_annotations():
   )
 
 def com_google_protobuf_java():
-  java_import_external(
+  native.http_archive(
       name = "com_google_protobuf_java",
-      jar_sha256 = "f3411ade77523d5f0d013d4f25c36879e66f0c5e1e4310f7096d54d0d2553554",
-      jar_urls = [
-          "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.3.0/protobuf-java-3.3.0.jar",
-          "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.3.0/protobuf-java-3.3.0.jar",
+      sha256 = "0cc6607e2daa675101e9b7398a436f09167dffb8ca0489b0307ff7260498c13c",
+      strip_prefix = "protobuf-3.5.0",
+      urls = [
+        "https://mirror.bazel.build/github.com/google/protobuf/archive/v3.5.0.tar.gz",
+        "https://github.com/google/protobuf/archive/v3.5.0.tar.gz",
       ],
-      licenses = ["notice"],  # New BSD and Apache 2.0
   )
 
 def com_google_protobuf_js():
@@ -774,7 +774,7 @@ def com_google_template_soy():
           "@com_google_inject_extensions_guice_assistedinject",
           "@com_google_inject_extensions_guice_multibindings",
           "@com_google_inject_guice",
-          "@com_google_protobuf_java",
+          "@com_google_protobuf_java//:protobuf_java",
           "@com_ibm_icu_icu4j",
           "@javax_inject",
           "@org_json",

--- a/java/com/google/javascript/jscomp/BUILD
+++ b/java/com/google/javascript/jscomp/BUILD
@@ -44,6 +44,6 @@ java_library(
         "@com_google_dagger",
         "@com_google_guava",
         "@com_google_javascript_closure_compiler",
-        "@com_google_protobuf_java",
+        "@com_google_protobuf_java//:protobuf_java",
     ],
 )

--- a/java/io/bazel/rules/closure/webfiles/BUILD
+++ b/java/io/bazel/rules/closure/webfiles/BUILD
@@ -31,7 +31,7 @@ java_library(
         "@com_google_code_findbugs_jsr305",
         "@com_google_dagger",
         "@com_google_guava",
-        "@com_google_protobuf_java",
+        "@com_google_protobuf_java//:protobuf_java",
         "@javax_inject",
         "@org_jsoup",
     ],

--- a/java/io/bazel/rules/closure/webfiles/server/BUILD
+++ b/java/io/bazel/rules/closure/webfiles/server/BUILD
@@ -32,7 +32,7 @@ java_library(
         "@com_google_code_findbugs_jsr305",
         "@com_google_dagger",
         "@com_google_guava",
-        "@com_google_protobuf_java",
+        "@com_google_protobuf_java//:protobuf_java",
         "@com_google_template_soy",
     ],
 )

--- a/java/io/bazel/rules/closure/worker/BUILD
+++ b/java/io/bazel/rules/closure/worker/BUILD
@@ -31,7 +31,7 @@ java_library(
         "@com_google_code_findbugs_jsr305",
         "@com_google_dagger",
         "@com_google_guava",
-        "@com_google_protobuf_java",
+        "@com_google_protobuf_java//:protobuf_java",
     ],
 )
 

--- a/javatests/io/bazel/rules/closure/worker/BUILD
+++ b/javatests/io/bazel/rules/closure/worker/BUILD
@@ -25,7 +25,7 @@ java_test(
         "@com_google_dagger",
         "@com_google_guava",
         "@com_google_jimfs",
-        "@com_google_protobuf_java",
+        "@com_google_protobuf_java//:protobuf_java",
         "@com_google_truth",
         "@junit",
         "@org_mockito_all",


### PR DESCRIPTION
Currently, @com_google_protobuf_java is defined by the protobuf-java
jars published on Maven Central, imported into rules_closure by
the java_import_external() Skylark rule.

Meanwhile, the protobuf repository is a Bazel repository. Its
//:protobuf_java target provides the same functionality as the
protobuf-java jars. Importing the protobuf repo via http_archive
is the [officially recommended way of using protos in Bazel](https://blog.bazel.build/2017/02/27/protocol-buffers.html).

This commit changes the definition of rules_closure's
@com_google_protobuf_java from the maven jar-based approach to
a real http_archive. This will allow downstream repos that currently
have the recommended proto setup to use rules_closure.