### PR TITLE
Remove com_google_protobuf_java

### DIFF
--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -66,6 +66,8 @@ def closure_repositories(
     omit_org_ow2_asm_util=False,
     omit_phantomjs=False):
   """Imports dependencies for Closure Rules."""
+  if omit_com_google_protobuf_java:
+    fail("omit_com_google_protobuf_java no longer supported and must be not be passed to closure_repositories()")
   if not omit_aopalliance:
     aopalliance()
   if not omit_args4j:
@@ -114,8 +116,6 @@ def closure_repositories(
     com_google_jsinterop_annotations()
   if not omit_com_google_protobuf:
     com_google_protobuf()
-  if not omit_com_google_protobuf_java:
-    com_google_protobuf_java()
   if not omit_com_google_protobuf_js:
     com_google_protobuf_js()
   if not omit_com_google_template_soy:
@@ -375,7 +375,7 @@ def com_google_common_html_types():
           "@com_google_errorprone_error_prone_annotations",
           "@com_google_guava",
           "@com_google_jsinterop_annotations",
-          "@com_google_protobuf_java//:protobuf_java",
+          "@com_google_protobuf//:protobuf_java",
           "@javax_annotation_jsr250_api",
       ],
   )
@@ -562,7 +562,7 @@ def com_google_javascript_closure_compiler():
           "@com_google_code_gson",
           "@com_google_guava",
           "@com_google_code_findbugs_jsr305",
-          "@com_google_protobuf_java//:protobuf_java",
+          "@com_google_protobuf//:protobuf_java",
       ],
       extra_build_file_content = "\n".join([
           "java_binary(",
@@ -629,17 +629,6 @@ def com_google_protobuf():
       ],
   )
 
-def com_google_protobuf_java():
-  native.http_archive(
-      name = "com_google_protobuf_java",
-      sha256 = "0cc6607e2daa675101e9b7398a436f09167dffb8ca0489b0307ff7260498c13c",
-      strip_prefix = "protobuf-3.5.0",
-      urls = [
-          "https://mirror.bazel.build/github.com/google/protobuf/archive/v3.5.0.tar.gz",
-          "https://github.com/google/protobuf/archive/v3.5.0.tar.gz",
-      ],
-  )
-
 def com_google_protobuf_js():
   native.new_http_archive(
       name = "com_google_protobuf_js",
@@ -670,7 +659,7 @@ def com_google_template_soy():
           "@com_google_inject_extensions_guice_assistedinject",
           "@com_google_inject_extensions_guice_multibindings",
           "@com_google_inject_guice",
-          "@com_google_protobuf_java//:protobuf_java",
+          "@com_google_protobuf//:protobuf_java",
           "@com_ibm_icu_icu4j",
           "@javax_inject",
           "@org_json",

--- a/java/com/google/javascript/jscomp/BUILD
+++ b/java/com/google/javascript/jscomp/BUILD
@@ -44,6 +44,6 @@ java_library(
         "@com_google_dagger",
         "@com_google_guava",
         "@com_google_javascript_closure_compiler",
-        "@com_google_protobuf_java//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java",
     ],
 )

--- a/java/io/bazel/rules/closure/webfiles/BUILD
+++ b/java/io/bazel/rules/closure/webfiles/BUILD
@@ -29,7 +29,7 @@ java_library(
         "@com_google_code_findbugs_jsr305",
         "@com_google_dagger",
         "@com_google_guava",
-        "@com_google_protobuf_java//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java",
         "@javax_inject",
         "@org_jsoup",
     ],

--- a/java/io/bazel/rules/closure/webfiles/server/BUILD
+++ b/java/io/bazel/rules/closure/webfiles/server/BUILD
@@ -31,7 +31,7 @@ java_library(
         "@com_google_code_findbugs_jsr305",
         "@com_google_dagger",
         "@com_google_guava",
-        "@com_google_protobuf_java//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java",
         "@com_google_template_soy",
     ],
 )

--- a/java/io/bazel/rules/closure/worker/BUILD
+++ b/java/io/bazel/rules/closure/worker/BUILD
@@ -29,7 +29,7 @@ java_library(
         "@com_google_code_findbugs_jsr305",
         "@com_google_dagger",
         "@com_google_guava",
-        "@com_google_protobuf_java//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java",
     ],
 )
 

--- a/javatests/io/bazel/rules/closure/worker/BUILD
+++ b/javatests/io/bazel/rules/closure/worker/BUILD
@@ -25,7 +25,7 @@ java_test(
         "@com_google_dagger",
         "@com_google_guava",
         "@com_google_jimfs",
-        "@com_google_protobuf_java//:protobuf_java",
+        "@com_google_protobuf//:protobuf_java",
         "@com_google_truth",
         "@junit",
         "@org_mockito_all",


### PR DESCRIPTION
Closes #248.

This was deprecated with Bazel 0.8.0, which now uses
@com_google_protobuf instead.

This change will break users that use
closure_repositories(omit_com_google_protobuf_java=True), so I've
added a custom error message to make the resolution clearer.

Test Plan:

  $ bazel test javatests/...

and confirm that the warning from #248 is gone.

Inspired-By: Rodrigo Queiro <overdrigzed@gmail.com>