### PR TITLE
Add js output to list of files when being used as a filegroup

### DIFF
--- a/closure/stylesheets/closure_css_binary.bzl
+++ b/closure/stylesheets/closure_css_binary.bzl
@@ -36,6 +36,7 @@ def _closure_css_binary(ctx):
           "--output-orientation", ctx.attr.orientation]
   if ctx.attr.renaming:
     outputs += [ctx.outputs.js]
+    files += [ctx.outputs.js]
     args += ["--output-renaming-map", ctx.outputs.js.path,
              "--output-renaming-map-format", "CLOSURE_COMPILED_SPLIT_HYPHENS"]
     if ctx.attr.debug:


### PR DESCRIPTION
I've been using the `closure_css_binary` rule in tandem with the `resources` attribute of a `java_library` rule. The `name.css` and `name.css.map` were being built into the jar correctly, but the `name.css.js` file was missing:

```
META-INF/
META-INF/MANIFEST.MF
logback.xml
css/
css/circuitcanyon_css_bin.css
css/circuitcanyon_css_bin.css.map
```

Since I'd like to load the mappings into a Java backend for making a `SoyCssRenamingMap`, I need this file to parse and render server side templates. This PR adds it to the file output:

```
META-INF/
META-INF/MANIFEST.MF
logback.xml
css/
css/circuitcanyon_css_bin.css
css/circuitcanyon_css_bin.css.map
css/circuitcanyon_css_bin.css.js
```