### PR TITLE
add new bazel ci configuration

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,20 @@
+---
+platforms:
+  ubuntu1404:
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."
+  ubuntu1604:
+    build_targets:
+    - "..."
+    test_targets:
+    - "..."
+  macos:
+    build_targets:
+    - "..."
+    test_targets:
+    - "--"
+    - "..."
+    # See https://github.com/bazelbuild/rules_closure/issues/247
+    - "-//closure/testing/test:noto_fonts_render_as_expected"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Closure Rules for Bazel (αlpha) ![Travis build status](https://travis-ci.org/bazelbuild/rules_closure.svg?branch=master)
+# Closure Rules for Bazel (αlpha) ![Travis build status](https://travis-ci.org/bazelbuild/rules_closure.svg?branch=master) [![Bazel CI build status](https://badge.buildkite.com/7569410e2a2661076591897283051b6d137f35102167253fed.svg)](https://buildkite.com/bazel/closure-compiler-rules-closure-postsubmit)
+
 
 JavaScript | Templating | Stylesheets | Miscellaneous
 --- | --- | --- | ---


### PR DESCRIPTION
@jart Bazel is moving to a new CI system. We are checking in the configuration for our CI system so that we can test rules_closure after every Bazel change to ensure we don't break you. Cheers!