### PR TITLE
Bump args4j to 2.33

### DIFF
--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -176,11 +176,11 @@ def aopalliance():
 def args4j():
   java_import_external(
       name = "args4j",
-      jar_sha256 = "989bda2321ea073a03686e9d4437ea4928c72c99f993f9ca6fab24615f0771a4",
+      jar_sha256 = "91ddeaba0b24adce72291c618c00bbdce1c884755f6c4dba9c5c46e871c69ed6",
       jar_urls = [
-          "https://mirror.bazel.build/repo1.maven.org/maven2/args4j/args4j/2.0.26/args4j-2.0.26.jar",
-          "https://repo1.maven.org/maven2/args4j/args4j/2.0.26/args4j-2.0.26.jar",
-          "http://maven.ibiblio.org/maven2/args4j/args4j/2.0.26/args4j-2.0.26.jar",
+          "https://mirror.bazel.build/repo1.maven.org/maven2/args4j/args4j/2.33/args4j-2.33.jar",
+          "https://repo1.maven.org/maven2/args4j/args4j/2.0.33/args4j-2.33.jar",
+          "http://maven.ibiblio.org/maven2/args4j/args4j/2.0.33/args4j-2.33.jar",
       ],
       licenses = ["notice"],  # MIT License
   )
@@ -657,10 +657,9 @@ def com_google_template_soy():
       name = "com_google_template_soy",
       licenses = ["notice"],  # Apache 2.0
       jar_urls = [
-          "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/template/soy/2018-01-03/soy-2018-01-03.jar",
-          "https://repo1.maven.org/maven2/com/google/template/soy/2018-01-03/soy-2018-01-03.jar",
+          "https://github.com/davido/closure-templates/releases/download/release-2018-03-18/soy-2018-03-18.jar",
       ],
-      jar_sha256 = "2952b430323a01070d73c7767e34c4030355b9e60c14b5165bebf69b2f6ad927",
+      jar_sha256 = "5a73bac4fec2d75982f0ce0900dffc6f9ceab42c3f6e40de1915e22854f7389b",
       deps = [
           "@args4j",
           "@com_google_code_findbugs_jsr305",

--- a/java/com/google/javascript/jscomp/JsChecker.java
+++ b/java/com/google/javascript/jscomp/JsChecker.java
@@ -323,6 +323,8 @@ public final class JsChecker {
       CmdLineParser parser = new CmdLineParser(checker);
       parser.setUsageWidth(80);
       try {
+        // Turn off interpreting @-prefixed options as being a file
+        parser.getProperties().withAtSyntax(false);
         parser.parseArgument(ImmutableList.copyOf(args));
       } catch (CmdLineException e) {
         System.err.println(e.getMessage());

--- a/java/io/bazel/rules/closure/webfiles/server/listing.soy
+++ b/java/io/bazel/rules/closure/webfiles/server/listing.soy
@@ -48,10 +48,10 @@
   <h1>Bazel Closure Rules</h1>
   <h3>{$label}</h3>
   <p>
-    {foreach $path in $paths}
+    {for $path in $paths}
       <a href="{$path}">{$path}</a><br>
     {ifempty}
       No srcs found in transitive closure with path component prefix matching
       request path.
-    {/foreach}
+    {/for}
 {/template}


### PR DESCRIPTION
Fixes: #221.

closure-template version is also updated to include this PR: [1].

[1] https://github.com/google/closure-templates/pull/155