### PR TITLE
closure_proto_library: propagate descriptors to closure_js_library

### DIFF
--- a/closure/protobuf/closure_proto_library.bzl
+++ b/closure/protobuf/closure_proto_library.bzl
@@ -93,6 +93,10 @@ def _closure_proto_aspect_impl(target, ctx):
   srcs = depset([js])
   deps = unfurl(ctx.rule.attr.deps, provider="closure_js_library")
   deps += [ctx.attr._closure_library, ctx.attr._closure_protobuf_jspb]
+  proto_deps = unfurl(ctx.rule.attr.deps, provider="proto")
+  descriptors = depset(
+    direct = target.files.to_list(),
+    transitive=[d.proto.transitive_descriptor_sets for d in proto_deps])
 
   suppress = [
       "missingProperties",
@@ -104,7 +108,8 @@ def _closure_proto_aspect_impl(target, ctx):
       srcs, deps, ctx.rule.attr.testonly, suppress, True,
 
       ctx.files._closure_library_base,
-      ctx.executable._ClosureWorker)
+      ctx.executable._ClosureWorker,
+      internal_descriptors = descriptors)
   return struct(
       exports = library.exports,
       closure_js_library=library.closure_js_library,

--- a/closure/templates/test/BUILD
+++ b/closure/templates/test/BUILD
@@ -18,15 +18,20 @@ licenses(["notice"])  # Apache 2.0
 
 load("//closure:defs.bzl", "closure_js_binary")
 load("//closure:defs.bzl", "closure_js_library")
-load("//closure:defs.bzl", "closure_js_proto_library")
+load("//closure:defs.bzl", "closure_proto_library")
 load("//closure:defs.bzl", "closure_js_template_library")
 load("//closure:defs.bzl", "closure_js_test")
 load("//closure:defs.bzl", "closure_java_template_library")
 load("//closure/private:file_test.bzl", "file_test")
 
-closure_js_proto_library(
+proto_library(
     name = "person_proto",
     srcs = ["person.proto"],
+)
+
+closure_proto_library(
+    name = "person_closure_proto",
+    deps = [":person_proto"],
 )
 
 closure_js_template_library(
@@ -37,7 +42,7 @@ closure_js_template_library(
 closure_js_template_library(
     name = "greeter_proto_soy",
     srcs = ["greeter_proto.soy"],
-    deps = [":person_proto"],
+    deps = [":person_closure_proto"],
 )
 
 closure_js_library(
@@ -54,7 +59,7 @@ closure_js_library(
     srcs = ["greeter_proto.js"],
     deps = [
         ":greeter_proto_soy",
-        ":person_proto",
+        ":person_closure_proto",
         "//closure/library/soy",
     ],
 )


### PR DESCRIPTION
Makes closure_proto_library a valid dependency for
closure_js_template_library rules.

Update test to use modern proto rule.