### PR TITLE
Make Auto Factory work with bazel 0.16.0

### DIFF
--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -61,6 +61,7 @@ def closure_repositories(
     omit_libfontconfig_amd64_deb=False,
     omit_libfreetype_amd64_deb=False,
     omit_libpng_amd64_deb=False,
+    omit_org_apache_tomcat_annotations_api=False,
     omit_org_json=False,
     omit_org_jsoup=False,
     omit_org_ow2_asm=False,
@@ -152,6 +153,8 @@ def closure_repositories(
     libfreetype_amd64_deb()
   if not omit_libpng_amd64_deb:
     libpng_amd64_deb()
+  if not omit_org_apache_tomcat_annotations_api:
+    org_apache_tomcat_annotations_api()
   if not omit_org_json:
     org_json()
   if not omit_org_jsoup:
@@ -249,6 +252,7 @@ def com_google_auto_factory():
           "        \"@com_google_java_format\",",
           "        \"@com_squareup_javapoet\",",
           "        \"@javax_inject\",",
+          "        \"@org_apache_tomcat_annotations_api\",",
           "    ],",
           ")",
           "",
@@ -856,6 +860,17 @@ def libpng_amd64_deb():
           "http://http.us.debian.org/debian/pool/main/libp/libpng/libpng12-0_1.2.50-2+deb8u2_amd64.deb",
       ],
       sha256 = "a57b6d53169c67a7754719f4b742c96554a18f931ca5b9e0408fb6502bb77e80",
+  )
+
+def org_apache_tomcat_annotations_api():
+  java_import_external(
+      name = "org_apache_tomcat_annotations_api",
+      licenses = ["notice"],  # Apache License, Version 2.0
+      jar_sha256 = "748677bebb1651a313317dfd93e984ed8f8c9e345538fa8b0ab0cbb804631953",
+      jar_urls = [
+	  "http://maven.ibiblio.org/maven2/org/apache/tomcat/tomcat-annotations-api/8.0.5/tomcat-annotations-api-8.0.5.jar",
+	  "http://repo1.maven.org/maven2/org/apache/tomcat/tomcat-annotations-api/8.0.5/tomcat-annotations-api-8.0.5.jar",
+      ],
   )
 
 def org_json():


### PR DESCRIPTION
Bazel 0.16.0 uses Java 9 to compile and as a result the `javax.annotation.Generated` class is no longer provided by the default module. Add an explicit dependency on it for `@com_google_auto_factory` target work again.

I tested by building a [dummy example](https://github.com/jianglai/auto_factory_example) with closure rules 0.8.0 which failed:

```
ERROR: /usr/local/google/home/jianglai/auto_factory_example/BUILD:1:1: Building libauto_factory_example.jar (1 source file) and runn
ing annotation processors (AutoFactoryProcessor) failed (Exit 1)                       
error: Failed to process @AutoFactory annotations:
  java.lang.NoClassDefFoundError: javax/annotation/Generated                                                                
        at com.google.auto.factory.processor.FactoryWriter.writeFactory(FactoryWriter.java:65)                                   
        at com.google.auto.factory.processor.AutoFactoryProcessor.doProcess(AutoFactoryProcessor.java:162)
        at com.google.auto.factory.processor.AutoFactoryProcessor.process(AutoFactoryProcessor.java:87)
        at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment.callProcessor(JavacProcessingEnvironment.java:968)
        at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment.discoverAndRunProcs(JavacProcessingEnvironment.jav
a:884)                                                        
        at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment.access$2200(JavacProcessingEnvironment.java:108)
        at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment$Round.run(JavacProcessingEnvironment.java:1206)
        at jdk.compiler/com.sun.tools.javac.processing.JavacProcessingEnvironment.doProcessing(JavacProcessingEnvironment.java:1315)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.processAnnotations(JavaCompiler.java:1246)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:922)
        at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.lambda$doCall$0(JavacTaskImpl.java:100)
        at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.handleExceptions(JavacTaskImpl.java:142)
        at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.doCall(JavacTaskImpl.java:96)
        at jdk.compiler/com.sun.tools.javac.api.JavacTaskImpl.call(JavacTaskImpl.java:90)
        at com.google.devtools.build.buildjar.javac.BlazeJavacMain.compile(BlazeJavacMain.java:110)
        at com.google.devtools.build.buildjar.SimpleJavaLibraryBuilder$2.invokeJavac(SimpleJavaLibraryBuilder.java:122)
        at com.google.devtools.build.buildjar.ReducedClasspathJavaLibraryBuilder.compileSources(ReducedClasspathJavaLibraryBuilder.j
ava:54)                                                       
        at com.google.devtools.build.buildjar.SimpleJavaLibraryBuilder.compileJavaLibrary(SimpleJavaLibraryBuilder.java:125)
        at com.google.devtools.build.buildjar.SimpleJavaLibraryBuilder.run(SimpleJavaLibraryBuilder.java:133)
        at com.google.devtools.build.buildjar.BazelJavaBuilder.processRequest(BazelJavaBuilder.java:105)
        at com.google.devtools.build.buildjar.BazelJavaBuilder.runPersistentWorker(BazelJavaBuilder.java:67)
        at com.google.devtools.build.buildjar.BazelJavaBuilder.main(BazelJavaBuilder.java:45)
  Caused by: java.lang.ClassNotFoundException: javax.annotation.Generated
        at java.base/java.net.URLClassLoader.findClass(Unknown Source)
        at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
        at java.base/java.lang.ClassLoader.loadClass(Unknown Source)             
        ... 22 more                                     
Target //:auto_factory_example failed to build  
```

Switching to the locally patched closure rules, the build succeeded.

```
INFO: Build options have changed, discarding analysis cache.
INFO: Analysed target //:auto_factory_example (23 packages loaded).
INFO: Found 1 target...
Target //:auto_factory_example up-to-date:
  bazel-bin/libauto_factory_example.jar
INFO: Elapsed time: 2.075s, Critical Path: 1.74s
INFO: 5 processes: 4 linux-sandbox, 1 worker.
INFO: Build completed successfully, 7 total actions
```