### PR TITLE
Remove deprecated Bazel features

### DIFF
--- a/closure/compiler/closure_js_binary.bzl
+++ b/closure/compiler/closure_js_binary.bzl
@@ -261,7 +261,7 @@ closure_js_binary = rule(
         "output_wrapper": attr.string(),
         "property_renaming_report": attr.output(),
         "warning_level": attr.string(default="VERBOSE"),
-        "data": attr.label_list(cfg="data", allow_files=True),
+        "data": attr.label_list(allow_files=True),
         "conformance": attr.label_list(allow_files=True),
         "suppress_on_all_sources_in_transitive_closure": attr.string_list(),
 

--- a/closure/compiler/closure_js_binary.bzl
+++ b/closure/compiler/closure_js_binary.bzl
@@ -203,7 +203,7 @@ def _impl(ctx):
   # all JavaScript sources in the transitive closure, sans dead code.
   argfile = create_argfile(ctx.actions, ctx.label.name, args)
   inputs.append(argfile)
-  ctx.action(
+  ctx.actions.run(
       inputs=inputs,
       outputs=outputs,
       executable=ctx.executable._ClosureWorker,

--- a/closure/compiler/closure_js_deps.bzl
+++ b/closure/compiler/closure_js_deps.bzl
@@ -79,7 +79,7 @@ closure_js_deps = rule(
     implementation=_impl,
     attrs={
         "deps": attr.label_list(),
-        "data": attr.label_list(cfg="data", allow_files=True),
+        "data": attr.label_list(allow_files=True),
         "_closure_library_base": CLOSURE_LIBRARY_BASE_ATTR,
         "_depswriter": attr.label(
             default=Label("@com_google_javascript_closure_library//:depswriter"),

--- a/closure/compiler/closure_js_deps.bzl
+++ b/closure/compiler/closure_js_deps.bzl
@@ -28,7 +28,7 @@ def _impl(ctx):
   closure_rel = '/'.join(['..' for _ in range(len(closure_root.split('/')))])
   outputs = [ctx.outputs.out]
   # XXX: Other files in same directory will get schlepped in w/o sandboxing.
-  ctx.action(
+  ctx.actions.run(
       inputs=list(js.srcs),
       outputs=outputs,
       arguments=(["--output_file=%s" % ctx.outputs.out.path] +

--- a/closure/compiler/closure_js_library.bzl
+++ b/closure/compiler/closure_js_library.bzl
@@ -340,7 +340,7 @@ closure_js_library = rule(
             # TODO(yannic): Define valid values.
             # values=["CLOSURE"],
         ),
-        "data": attr.label_list(cfg="data", allow_files=True),
+        "data": attr.label_list(allow_files=True),
         "deps": attr.label_list(
             aspects=[closure_js_aspect],
             providers=["closure_js_library"]),

--- a/closure/private/defs.bzl
+++ b/closure/private/defs.bzl
@@ -15,12 +15,12 @@
 """Common build definitions for Closure Compiler build definitions.
 """
 
-CSS_FILE_TYPE = FileType([".css", ".gss"])
-HTML_FILE_TYPE = FileType([".html"])
-JS_FILE_TYPE = FileType([".js"])
+CSS_FILE_TYPE = [".css", ".gss"]
+HTML_FILE_TYPE = [".html"]
+JS_FILE_TYPE = [".js"]
 JS_LANGUAGE_DEFAULT = "ECMASCRIPT5_STRICT"
-JS_TEST_FILE_TYPE = FileType(["_test.js"])
-SOY_FILE_TYPE = FileType([".soy"])
+JS_TEST_FILE_TYPE = ["_test.js"]
+SOY_FILE_TYPE = [".soy"]
 
 JS_LANGUAGE_IN = "ECMASCRIPT_2017"
 JS_LANGUAGE_OUT_DEFAULT = "ECMASCRIPT5"

--- a/closure/private/file_test.bzl
+++ b/closure/private/file_test.bzl
@@ -51,8 +51,7 @@ _file_test = rule(
     attrs = {
         "file": attr.label(
             mandatory = True,
-            allow_files = True,
-            single_file = True,
+            allow_single_file = True,
         ),
         "content": attr.string(default = ""),
         "regexp": attr.string(default = ""),

--- a/closure/private/files_equal_test.bzl
+++ b/closure/private/files_equal_test.bzl
@@ -50,12 +50,10 @@ _files_equal_test = rule(
     attrs = {
         "golden": attr.label(
             mandatory = True,
-            allow_files = True,
-            single_file = True),
+            allow_single_file = True),
         "actual": attr.label(
             mandatory = True,
-            allow_files = True,
-            single_file = True),
+            allow_single_file = True),
         "error_message": attr.string(
             default="FILES DO NOT HAVE EQUAL CONTENTS"),
     },

--- a/closure/stylesheets/closure_css_binary.bzl
+++ b/closure/stylesheets/closure_css_binary.bzl
@@ -87,7 +87,7 @@ closure_css_binary = rule(
         "orientation": attr.string(default="NOCHANGE"),
         "renaming": attr.bool(default=True),
         "vendor": attr.string(),
-        "data": attr.label_list(cfg="data", allow_files=True),
+        "data": attr.label_list(allow_files=True),
         "_compiler": attr.label(
             default=Label(
                 "@com_google_closure_stylesheets//:ClosureCommandLineCompiler"),

--- a/closure/stylesheets/closure_css_binary.bzl
+++ b/closure/stylesheets/closure_css_binary.bzl
@@ -54,7 +54,7 @@ def _closure_css_binary(ctx):
   for f in css.srcs:
     args.append(f.path)
     inputs.append(f)
-  ctx.action(
+  ctx.actions.run(
       inputs=inputs,
       outputs=outputs,
       arguments=args,

--- a/closure/stylesheets/closure_css_library.bzl
+++ b/closure/stylesheets/closure_css_library.bzl
@@ -40,7 +40,7 @@ closure_css_library = rule(
     implementation=_closure_css_library,
     attrs={
         "srcs": attr.label_list(allow_files=CSS_FILE_TYPE),
-        "data": attr.label_list(cfg="data", allow_files=True),
+        "data": attr.label_list(allow_files=True),
         "deps": attr.label_list(providers=["closure_css_library"]),
         "exports": attr.label_list(),
         "orientation": attr.string(default="LTR"),

--- a/closure/templates/closure_js_template_library.bzl
+++ b/closure/templates/closure_js_template_library.bzl
@@ -62,7 +62,7 @@ _closure_js_template_library = rule(
             aspects=[closure_js_aspect],
             providers=["closure_js_library"]),
         "outputs": attr.output_list(),
-        "globals": attr.label(allow_files=True, single_file=True),
+        "globals": attr.label(allow_single_file=True),
         "plugin_modules": attr.label_list(),
         "should_provide_require_soy_namespaces": attr.bool(default=True),
         "should_generate_soy_msg_defs": attr.bool(),

--- a/closure/templates/closure_js_template_library.bzl
+++ b/closure/templates/closure_js_template_library.bzl
@@ -43,7 +43,7 @@ def _impl(ctx):
     for f in dep.closure_js_library.descriptors:
       args += ["--protoFileDescriptors=%s" % f.path]
       inputs.append(f)
-  ctx.action(
+  ctx.actions.run(
       inputs=inputs,
       outputs=ctx.outputs.outputs,
       executable=ctx.executable.compiler,

--- a/closure/testing/phantomjs_test.bzl
+++ b/closure/testing/phantomjs_test.bzl
@@ -64,8 +64,7 @@ _phantomjs_test = rule(
             providers=["closure_js_binary"],
             default=Label("//closure/testing:phantomjs_harness_bin")),
         "html": attr.label(
-            single_file=True,
-            allow_files=HTML_FILE_TYPE,
+            allow_single_file=HTML_FILE_TYPE,
             default=Label("//closure/testing:empty.html")),
         "data": attr.label_list(allow_files=True),
         "_phantomjs": attr.label(

--- a/closure/testing/phantomjs_test.bzl
+++ b/closure/testing/phantomjs_test.bzl
@@ -67,7 +67,7 @@ _phantomjs_test = rule(
             single_file=True,
             allow_files=HTML_FILE_TYPE,
             default=Label("//closure/testing:empty.html")),
-        "data": attr.label_list(cfg="data", allow_files=True),
+        "data": attr.label_list(allow_files=True),
         "_phantomjs": attr.label(
             default=Label("//third_party/phantomjs"),
             executable=True,

--- a/closure/webfiles/web_library.bzl
+++ b/closure/webfiles/web_library.bzl
@@ -103,7 +103,7 @@ def _web_library(ctx):
     args.append(man.path)
   argfile = create_argfile(ctx.actions, ctx.label.name, args)
   inputs.append(argfile)
-  ctx.action(
+  ctx.actions.run(
       inputs=inputs,
       outputs=[ctx.outputs.dummy],
       executable=ctx.executable._ClosureWorker,

--- a/closure/webfiles/web_library.bzl
+++ b/closure/webfiles/web_library.bzl
@@ -188,7 +188,7 @@ web_library = rule(
         "srcs": attr.label_list(allow_files=True),
         "deps": attr.label_list(providers=["webfiles"]),
         "exports": attr.label_list(),
-        "data": attr.label_list(cfg="data", allow_files=True),
+        "data": attr.label_list(allow_files=True),
         "suppress": attr.string_list(),
         "strip_prefix": attr.string(),
         "external_assets": attr.string_dict(default={"/_/runfiles": "."}),


### PR DESCRIPTION
This makes rules_closure compatible with `--all_incompatible_changes`, best I can tell.