### PR TITLE
Fix strict deps warning

### DIFF
--- a/java/io/bazel/rules/closure/BUILD
+++ b/java/io/bazel/rules/closure/BUILD
@@ -26,6 +26,7 @@ java_binary(
     deps = [
         "//java/com/google/javascript/jscomp",
         "//java/io/bazel/rules/closure/webfiles",
+        "//java/io/bazel/rules/closure/webfiles/compiler",
         "//java/io/bazel/rules/closure/worker",
         "@com_google_dagger",
         "@com_google_guava",


### PR DESCRIPTION
New version of turbine detects this as a layering violation (https://buildkite.com/bazel/bazel-with-downstream-projects-bazel/builds/515#f0057ef6-e13b-48f4-a7be-95488fcc52d6).