### PR TITLE
Specify entry_points for ES6 modules

### DIFF
--- a/closure/compiler/test/strict_dependency_checking/BUILD
+++ b/closure/compiler/test/strict_dependency_checking/BUILD
@@ -252,6 +252,9 @@ closure_js_library(
 
 closure_js_binary(
     name = "es6_g2_bin",
+    entry_points = [
+        "closure/compiler/test/strict_dependency_checking/es6_g2.js",
+    ],
     deps = [":es6_g2"],
 )
 
@@ -273,6 +276,9 @@ closure_js_library(
 
 closure_js_binary(
     name = "es6_relative_imports_bin",
+    entry_points = [
+        "closure/compiler/test/strict_dependency_checking/subdir/es6_e.js",
+    ],
     deps = [":es6_relative_imports_lib"],
 )
 


### PR DESCRIPTION
ES6 modules will soon no longer be considered "moochers" and dropped if not reachable from the entry points.