### PR TITLE
Fix closure js aspect actions to always use param files

### DIFF
--- a/closure/compiler/closure_js_aspect.bzl
+++ b/closure/compiler/closure_js_aspect.bzl
@@ -19,7 +19,6 @@ load(
     "collect_js",
     "collect_runfiles",
     "convert_path_to_es6_module_name",
-    "create_argfile",
     "find_js_module_roots",
     "make_jschecker_progress_message",
     "unfurl",


### PR DESCRIPTION
This is a no-op for open-source since it affects only non-open sourced parts of the file.