### PR TITLE
Adds support for zip inputs as src.

### DIFF
--- a/closure/compiler/closure_js_binary.bzl
+++ b/closure/compiler/closure_js_binary.bzl
@@ -209,6 +209,8 @@ def _impl(ctx):
     # We shall now pass all transitive sources, including externs files.
     for src in js.srcs:
         inputs.append(src)
+        if src.path.endswith(".zip"):
+            all_args.append("--jszip")
         all_args.add_all(
             [src],
             map_each = get_jsfile_path,

--- a/closure/private/defs.bzl
+++ b/closure/private/defs.bzl
@@ -194,8 +194,8 @@ def sort_roots(roots):
 
 def convert_path_to_es6_module_name(path, roots):
     """Equivalent to JsCheckerHelper#convertPathToModuleName."""
-    if not path.endswith(".js"):
-        fail("Path didn't end with .js: %s" % path)
+    if not path.endswith(".js") and not path.endswith(".zip"):
+        fail("Path didn't end with .js or .zip: %s" % path)
     module = path[:-3]
     for root in roots:
         if module.startswith(root + "/"):

--- a/java/com/google/javascript/jscomp/JsChecker.java
+++ b/java/com/google/javascript/jscomp/JsChecker.java
@@ -312,10 +312,15 @@ public final class JsChecker {
     return errorManager.getErrorCount() == 0;
   }
 
-  private static ImmutableList<SourceFile> getSourceFiles(Iterable<String> filenames) {
+  private static ImmutableList<SourceFile> getSourceFiles(Iterable<String> filenames)
+      throws IOException {
     ImmutableList.Builder<SourceFile> result = new ImmutableList.Builder<>();
     for (String filename : filenames) {
-      result.add(SourceFile.fromFile(filename));
+      if (filename.endsWith(".zip")) {
+        result.addAll(SourceFile.fromZipFile(filename, UTF_8));
+      } else {
+        result.add(SourceFile.fromFile(filename));
+      }
     }
     return result.build();
   }


### PR DESCRIPTION
JsCompiler already supports zip input for a while and we are planning to use these rules for J2CL opensource.