### PR TITLE
Fix compilation_level=BUNDLE for closure_js_binary

### DIFF
--- a/closure/compiler/test/BUILD
+++ b/closure/compiler/test/BUILD
@@ -51,6 +51,13 @@ file_test(
     file = "hello_bin.js.map",
 )
 
+# Make sure bazel doesn't complain about some outputs not created.
+closure_js_binary(
+    name = "hello_bin_bundle",
+    deps = [":hello_lib"],
+	compilation_level = "BUNDLE",
+)
+
 closure_js_binary(
     name = "hello_wrap_bin",
     language = "ECMASCRIPT3",

--- a/java/com/google/javascript/jscomp/JsCompiler.java
+++ b/java/com/google/javascript/jscomp/JsCompiler.java
@@ -202,10 +202,14 @@ public final class JsCompiler implements CommandLineProgram {
       if (jsOutputFile != null) {
         Files.write(jsOutputFile, EMPTY_BYTE_ARRAY);
       }
-      if (createSourceMap != null) {
-        Files.write(createSourceMap, EMPTY_BYTE_ARRAY);
-      }
     }
+
+    // Make sure a source map is always created since Bazel expect that but JsCompiler
+    // may not emit sometimes (e.g compiler_level=BUNLDE)
+    if (createSourceMap != null && !Files.exists(createSourceMap)) {
+      Files.write(createSourceMap, EMPTY_BYTE_ARRAY);
+    }
+
     if (!failed && expectFailure) {
       System.err.println("ERROR: Expected failure but didn't fail.");
     }


### PR DESCRIPTION
closure_js_binary always advertises the sourcemap output however compiler
may not generate it (e.g. compilation_level=BUNLDLE). This patch
fixes that so the output is always generated by providing an emtpy one
if compiler didn't generate it.