### PR TITLE
web_library: respect NO_COLOR environment variable

### DIFF
--- a/java/io/bazel/rules/closure/webfiles/server/WebfilesServer.java
+++ b/java/io/bazel/rules/closure/webfiles/server/WebfilesServer.java
@@ -15,6 +15,7 @@
 package io.bazel.rules.closure.webfiles.server;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.io.Resources.getResource;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -58,9 +59,13 @@ public final class WebfilesServer implements Runnable {
 
   private static final Logger logger = Logger.getLogger(WebfilesServer.class.getName());
 
-  private static final String BLUE = "\u001b[34m";
-  private static final String BOLD = "\u001b[1m";
-  private static final String RESET = "\u001b[0m";
+  private static final boolean WANT_COLOR =
+      System.getenv("NO_COLOR") == null &&
+      nullToEmpty(System.getenv("TERM")).contains("xterm");
+
+  private static final String BLUE = WANT_COLOR ? "\u001b[34m" : "";
+  private static final String BOLD = WANT_COLOR ? "\u001b[1m" : "";
+  private static final String RESET = WANT_COLOR ? "\u001b[0m" : "";
 
   public static void main(String[] args) throws Exception {
     ExecutorService executor = Executors.newCachedThreadPool();

--- a/java/io/bazel/rules/closure/worker/Prefixes.java
+++ b/java/io/bazel/rules/closure/worker/Prefixes.java
@@ -19,7 +19,9 @@ import static com.google.common.base.Strings.nullToEmpty;
 /** Bazel error prefixes. */
 public final class Prefixes {
 
-  private static final boolean WANT_COLOR = nullToEmpty(System.getenv("TERM")).contains("xterm");
+  private static final boolean WANT_COLOR =
+      System.getenv("NO_COLOR") == null &&
+      nullToEmpty(System.getenv("TERM")).contains("xterm");
 
   private static final String RESET = WANT_COLOR ? "\u001b[0m" : "";
   private static final String BOLD = WANT_COLOR ? "\u001b[1m" : "";


### PR DESCRIPTION
Summary:
Prior to this commit, there was no way to prevent the webfiles server
from emitting ANSI color codes, even if the output is not to a TTY or
the terminal is not xterm. This commit teaches the webfiles server about
the `NO_COLOR` environment variable, which, if set to any value
(including empty) will prevent the emission of any ANSI codes.
See: <https://no-color.org/>

(Ideally, we would also default to no-color when stderr is not a TTY, as
Bazel itself does, but it looks getting that information precisely
requires dropping down into C++ land.)

Test Plan:

```
$ unset NO_COLOR
$ bazel run //closure/webfiles/test:raven 2>&1 |
> stdbuf -o0 grep 'Closure Rules' | xxd
00000000: 1b5b 3334 6d43 6c6f 7375 7265 2052 756c  .[34mClosure Rul
00000010: 6573 201b 5b31 6d57 6562 6669 6c65 7353  es .[1mWebfilesS
$ NO_COLOR=1 bazel run //closure/webfiles/test:raven 2>&1 |
> stdbuf -o0 grep 'Closure Rules' | xxd
00000000: 436c 6f73 7572 6520 5275 6c65 7320 5765  Closure Rules We
$ NO_COLOR= bazel run //closure/webfiles/test:raven 2>&1 |
> stdbuf -o0 grep 'Closure Rules' | xxd
00000000: 436c 6f73 7572 6520 5275 6c65 7320 5765  Closure Rules We
```

wchargin-branch: web-library-no-color