### PR TITLE
Bump protobuf version to 3.6.1.2 (2)

### DIFF
--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -693,7 +693,7 @@ def com_google_protobuf_js():
             "https://github.com/protocolbuffers/protobuf/archive/v3.6.1.2.tar.gz",
         ],
         sha256 = "2244b0308846bb22b4ff0bcc675e99290ff9f1115553ae9671eba1030af31bc0",
-        strip_prefix = "protobuf-7b28271a61a3da0a37f6fda399b0c4c86464e5b3/js",
+        strip_prefix = "protobuf-3.6.1.2/js",
         build_file = str(Label("//closure/protobuf:protobuf_js.BUILD")),
     )
 

--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -680,6 +680,7 @@ def com_google_protobuf():
         strip_prefix = "protobuf-3.6.1.2",
         sha256 = "2244b0308846bb22b4ff0bcc675e99290ff9f1115553ae9671eba1030af31bc0",
         urls = [
+            "https://mirror.bazel.build/github.com/google/protobuf/archive/v3.6.1.2.tar.gz",
             "https://github.com/protocolbuffers/protobuf/archive/v3.6.1.2.tar.gz",
         ],
     )
@@ -688,9 +689,10 @@ def com_google_protobuf_js():
     http_archive(
         name = "com_google_protobuf_js",
         urls = [
-            "https://github.com/google/protobuf/archive/7b28271a61a3da0a37f6fda399b0c4c86464e5b3.tar.gz",
+            "https://mirror.bazel.build/github.com/google/protobuf/archive/v3.6.1.2.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/v3.6.1.2.tar.gz",
         ],
-        sha256 = "9dac7d7cf6e2c88bf92915f9338a26950531c00c05bf86764ab978344b69a45a",
+        sha256 = "2244b0308846bb22b4ff0bcc675e99290ff9f1115553ae9671eba1030af31bc0",
         strip_prefix = "protobuf-7b28271a61a3da0a37f6fda399b0c4c86464e5b3/js",
         build_file = str(Label("//closure/protobuf:protobuf_js.BUILD")),
     )


### PR DESCRIPTION
Following up https://github.com/bazelbuild/rules_closure/pull/313/files, where we missed `com_google_protobuf_js`

/cc @davido @buchgr @laurentlb  