### PR TITLE
Migrate protobuf info provider to new-style one.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ os:
   - osx
 
 env:
-  - BAZEL=0.19.0
+  - BAZEL=0.22.0
 
 before_install:
   - |

--- a/closure/protobuf/closure_proto_library.bzl
+++ b/closure/protobuf/closure_proto_library.bzl
@@ -63,7 +63,7 @@ def _generate_closure_js(target, ctx):
 
     # Add include paths for all proto files,
     # to avoid copying/linking the files for every target.
-    protos = target.proto.transitive_imports
+    protos = target[ProtoInfo].transitive_imports
     args = ["-I%s" % p for p in _proto_include_paths(protos)]
 
     out_options = ",".join(js_out_options)
@@ -71,7 +71,7 @@ def _generate_closure_js(target, ctx):
     args += ["--js_out=%s:%s" % (out_options, out_path)]
 
     # Add paths of protos we generate files for.
-    args += [file.path for file in target.proto.direct_sources]
+    args += [file.path for file in target[ProtoInfo].direct_sources]
 
     ctx.actions.run(
         inputs = protos,
@@ -145,7 +145,7 @@ closure_proto_library = rule(
     attrs = {
         "deps": attr.label_list(
             mandatory = True,
-            providers = ["proto"],
+            providers = [ProtoInfo],
             aspects = [closure_proto_aspect],
         ),
     },


### PR DESCRIPTION
This migrates the provider containing information about protocol buffers from the old-style 'dep.proto' pattern to the new-style 'dep[ProtoInfo]' one.