### PR TITLE
Replace the dep for JsCompiler to ease running the repo inside Google.

### DIFF
--- a/java/com/google/javascript/jscomp/BUILD
+++ b/java/com/google/javascript/jscomp/BUILD
@@ -37,13 +37,13 @@ java_library(
         "//javatests/com/google/javascript/jscomp:__pkg__",
     ],
     deps = [
+        "//closure/compiler",
         "//java/io/bazel/rules/closure:build_info_java_proto",
         "//java/io/bazel/rules/closure:webpath",
         "//java/io/bazel/rules/closure/worker",
         "@args4j",
         "@com_google_dagger",
         "@com_google_guava",
-        "@com_google_javascript_closure_compiler",
         "@com_google_protobuf//:protobuf_java",
     ],
 )


### PR DESCRIPTION
This is no-op for open-source users.