### PR TITLE
Actually update protobuf to 3.7.0

### DIFF
--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -70,7 +70,7 @@ def closure_repositories(
         omit_phantomjs = False):
     """Imports dependencies for Closure Rules."""
     if omit_com_google_protobuf_java:
-        fail("omit_com_google_protobuf_java no longer supported and must be not be passed to closure_repositories()")
+        fail("omit_com_google_protobuf_java no longer supported and must not be passed to closure_repositories()")
     if not omit_aopalliance:
         aopalliance()
     if not omit_args4j:
@@ -676,23 +676,21 @@ def com_google_jsinterop_annotations():
 def com_google_protobuf():
     http_archive(
         name = "com_google_protobuf",
-        strip_prefix = "protobuf-3.6.1.3",
-        sha256 = "73fdad358857e120fd0fa19e071a96e15c0f23bb25f85d3f7009abfd4f264a2a",
+        strip_prefix = "protobuf-059851fe59d2ac3123f79e0638cb209265e24130",
+        sha256 = "838191ec49807b0f8f556fb674c2e5fbe0597252e5e8c8e2b726c504061d9ea7",
         urls = [
-            "https://mirror.bazel.build/github.com/google/protobuf/archive/v3.6.1.3.tar.gz",
-            "https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/059851fe59d2ac3123f79e0638cb209265e24130.tar.gz",
         ],
     )
 
 def com_google_protobuf_js():
     http_archive(
         name = "com_google_protobuf_js",
-        strip_prefix = "protobuf-3.6.1.3/js",
+        strip_prefix = "protobuf-059851fe59d2ac3123f79e0638cb209265e24130/js",
         urls = [
-            "https://mirror.bazel.build/github.com/google/protobuf/archive/v3.6.1.3.tar.gz",
-            "https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/059851fe59d2ac3123f79e0638cb209265e24130.tar.gz",
         ],
-        sha256 = "73fdad358857e120fd0fa19e071a96e15c0f23bb25f85d3f7009abfd4f264a2a",
+        sha256 = "838191ec49807b0f8f556fb674c2e5fbe0597252e5e8c8e2b726c504061d9ea7",
         build_file = str(Label("//closure/protobuf:protobuf_js.BUILD")),
     )
 


### PR DESCRIPTION
In: [1] the prerequisites were added to rules_closure for protobuf
upgrade to the version 3.7.0:

* Dependency on bazel_skylib
* Dependency on zlib

In this change the protobuf version is updated to 3.7.0.

[1] https://github.com/bazelbuild/rules_closure/pull/341