### PR TITLE
Fix incompatibility in closure/filegroup_external.bzl

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,8 +3,21 @@ workspace(name = "io_bazel_rules_closure")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//closure/private:java_import_external.bzl", "java_import_external")
 load("//closure:repositories.bzl", "closure_repositories")
+load("//closure:defs.bzl", "filegroup_external")
 
 closure_repositories()
+
+
+filegroup_external(
+    name = "org_python_license",
+    licenses = ["notice"],  # Python 2.0
+    sha256_urls = {
+        "7ca8f169368827781684f7f20876d17b4415bbc5cb28baa4ca4652f0dda05e9f": [
+            "https://mirror.bazel.build/docs.python.org/2.7/_sources/license.rst.txt",
+            "https://docs.python.org/2.7/_sources/license.rst.txt",
+            ],
+        },
+)
 
 http_archive(
     name = "net_zlib",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,21 +3,8 @@ workspace(name = "io_bazel_rules_closure")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//closure/private:java_import_external.bzl", "java_import_external")
 load("//closure:repositories.bzl", "closure_repositories")
-load("//closure:defs.bzl", "filegroup_external")
 
 closure_repositories()
-
-
-filegroup_external(
-    name = "org_python_license",
-    licenses = ["notice"],  # Python 2.0
-    sha256_urls = {
-        "7ca8f169368827781684f7f20876d17b4415bbc5cb28baa4ca4652f0dda05e9f": [
-            "https://mirror.bazel.build/docs.python.org/2.7/_sources/license.rst.txt",
-            "https://docs.python.org/2.7/_sources/license.rst.txt",
-            ],
-        },
-)
 
 http_archive(
     name = "net_zlib",

--- a/closure/filegroup_external.bzl
+++ b/closure/filegroup_external.bzl
@@ -30,11 +30,11 @@ def _filegroup_external(ctx):
             basename = url[url.rindex("/") + 1:] or basename
             if url in downloaded.to_list():
                 fail("url specified multiple times: " + url)
-            downloaded += [url]
+            downloaded = depset([url], transitive = [downloaded])
         basename = _get_match(ctx.attr.rename, urls) or basename
         if basename in basenames.to_list():
             fail("filegroup path collision: " + basename)
-        basenames += [basename]
+        basenames = depset([basename], transitive = [basenames])
         if extract:
             inferred_srcs = None
             ctx.download_and_extract(
@@ -46,7 +46,7 @@ def _filegroup_external(ctx):
             )
         else:
             if inferred_srcs != None:
-                inferred_srcs += [basename]
+                inferred_srcs = depset([basename], transitive = [inferred_srcs])
             ctx.download(
                 urls,
                 basename,

--- a/closure/filegroup_external.bzl
+++ b/closure/filegroup_external.bzl
@@ -80,9 +80,9 @@ def _filegroup_external(ctx):
         lines.append("        ],")
         lines.append("    ),")
     else:
-        lines.append("    srcs = %s," % _repr_list(srcs))
+        lines.append("    srcs = %s," % _repr_list(srcs.to_list()))
     if data:
-        lines.append("    data = %s," % _repr_list(data))
+        lines.append("    data = %s," % _repr_list(data.to_list()))
     if ctx.attr.path:
         lines.append("    path = %s," % repr(ctx.attr.path))
     if ctx.attr.visibility:


### PR DESCRIPTION
Found this issue when building TensorFlow with `--incompatible_depset_is_not_iterable` and `--incompatible_depset_union`:
```
filegroup_external(
    name = "org_python_license",
    licenses = ["notice"],  # Python 2.0
    sha256_urls = {
        "7ca8f169368827781684f7f20876d17b4415bbc5cb28baa4ca4652f0dda05e9f": [
            "https://mirror.bazel.build/docs.python.org/2.7/_sources/license.rst.txt",
            "https://docs.python.org/2.7/_sources/license.rst.txt",
            ],
        },
)
```