### PR TITLE
Use a sandboxed openssl.cnf file for phantomjs

### DIFF
--- a/third_party/openssl/BUILD
+++ b/third_party/openssl/BUILD
@@ -1,0 +1,7 @@
+licenses(["unencumbered"])
+
+filegroup(
+    name = "files",
+    srcs = ["openssl.cnf"],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/openssl/openssl.cnf
+++ b/third_party/openssl/openssl.cnf
@@ -1,0 +1,1 @@
+# An empty openssl.cnf file seems to be good enough for phantomjs

--- a/third_party/phantomjs/BUILD
+++ b/third_party/phantomjs/BUILD
@@ -26,6 +26,7 @@ sh_binary(
         "//third_party/fontconfig:config",
         "//third_party/fontconfig:libfontconfig_k8",
         "//third_party/freetype:libfreetype_k8",
+        "//third_party/openssl:files",
         "//third_party/png:libpng_k8",
     ],
 )

--- a/third_party/phantomjs/phantomjs.sh
+++ b/third_party/phantomjs/phantomjs.sh
@@ -34,6 +34,7 @@ export OPENSSL_CONF=/etc/ssl/
 export FONTCONFIG_PATH="${RUNFILES}/third_party/fontconfig"
 export XDG_DATA_HOME="${RUNFILES}"
 export XDG_CACHE_HOME="$(mktemp -d "${TMPDIR:-/tmp}/fontcache.XXXXXXXXXX")"
+export OPENSSL_CONF="${RUNFILES}/third_party/openssl/openssl.cnf"
 
 "${RUNFILES}/third_party/phantomjs/bin/phantomjs" "$@"
 rc="$?"


### PR DESCRIPTION
Debian buster has changed /etc/ssl/openssl.cnf far enough that the
openssl built into phantomjs can't parse it.  I found this out by
stracing a test run and watching it access /etc/ssl/openssl.cnf.  We
want bazel to not rely on anything outside the sandbox.  The error that
is returned otherwise is:

140302110000960:error:25066067:DSO support routines:DLFCN_LOAD:could not load the shared library:dso_dlfcn.c:185:filename(libssl_conf.so): libssl_conf.so: cannot open shared object file: No such file or directory
140302110000960:error:25070067:DSO support routines:DSO_load:could not load the shared library:dso_lib.c:244:
140302110000960:error:0E07506E:configuration file routines:MODULE_LOAD_DSO:error loading dso:conf_mod.c:285:module=ssl_conf, path=ssl_conf
140302110000960:error:0E076071:configuration file routines:MODULE_RUN:unknown module name:conf_mod.c:222:module=ssl_conf

Fixes: #351