### PR TITLE
Remove references to goog.soy.REQUIRE_STRICT_AUTOESCAPE

### DIFF
--- a/closure/compiler/closure_js_binary.bzl
+++ b/closure/compiler/closure_js_binary.bzl
@@ -84,7 +84,6 @@ def _impl(ctx):
         "--generate_exports",
         "--process_closure_primitives",
         "--define=goog.json.USE_NATIVE_JSON",
-        "--define=goog.soy.REQUIRE_STRICT_AUTOESCAPE",
         "--hide_warnings_for=closure/goog/base.js",
     ]
 


### PR DESCRIPTION
It's going to be deleted as all Soy templates are now strict.