### PR TITLE
Update repositories.bzl

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ First you must [install Bazel]. Then you add the following to your `WORKSPACE`
 file:
 
 ```python
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 http_archive(
     name = "io_bazel_rules_closure",
     sha256 = "a80acb69c63d5f6437b099c111480a4493bad4592015af2127a2f49fb7512d8d",

--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -21,8 +21,8 @@ load("//closure/private:platform_http_file.bzl", "platform_http_file")
 def closure_repositories(
         omit_aopalliance = False,
         omit_args4j = False,
-        omit_clang = False,
         omit_bazel_skylib = False,
+        omit_clang = False,
         omit_com_google_auto_common = False,
         omit_com_google_auto_factory = False,
         omit_com_google_auto_value = False,
@@ -77,10 +77,10 @@ def closure_repositories(
         aopalliance()
     if not omit_args4j:
         args4j()
-    if not omit_clang:
-        clang()
     if not omit_bazel_skylib:
         bazel_skylib()
+    if not omit_clang:
+        clang()
     if not omit_com_google_auto_common:
         com_google_auto_common()
     if not omit_com_google_auto_factory:
@@ -199,6 +199,14 @@ def args4j():
         licenses = ["notice"],  # MIT License
     )
 
+def bazel_skylib():
+    http_archive(
+        name = "bazel_skylib",
+        sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
+        strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
+    )
+
 def clang():
     platform_http_file(
         name = "clang",
@@ -212,14 +220,6 @@ def clang():
             "http://llvm.org/releases/3.8.0/clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz",
         ],
         macos_sha256 = "e5a961e04b0e1738bbb5b824886a34932dc13b0af699d1fe16519d814d7b776f",
-    )
-
-def bazel_skylib():
-    http_archive(
-        name = "bazel_skylib",
-        sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
-        strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
     )
 
 def com_google_auto_common():

--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -22,6 +22,7 @@ def closure_repositories(
         omit_aopalliance = False,
         omit_args4j = False,
         omit_clang = False,
+        omit_bazel_skylib = False,
         omit_com_google_auto_common = False,
         omit_com_google_auto_factory = False,
         omit_com_google_auto_value = False,
@@ -67,7 +68,8 @@ def closure_repositories(
         omit_org_ow2_asm_commons = False,
         omit_org_ow2_asm_tree = False,
         omit_org_ow2_asm_util = False,
-        omit_phantomjs = False):
+        omit_phantomjs = False,
+        omit_zlib = False):
     """Imports dependencies for Closure Rules."""
     if omit_com_google_protobuf_java:
         fail("omit_com_google_protobuf_java no longer supported and must be not be passed to closure_repositories()")
@@ -77,6 +79,8 @@ def closure_repositories(
         args4j()
     if not omit_clang:
         clang()
+    if not omit_bazel_skylib:
+        bazel_skylib()
     if not omit_com_google_auto_common:
         com_google_auto_common()
     if not omit_com_google_auto_factory:
@@ -167,6 +171,8 @@ def closure_repositories(
         org_ow2_asm_util()
     if not omit_phantomjs:
         phantomjs()
+    if not omit_zlib:
+        zlib()
 
 # BEGIN_DECLARATIONS
 
@@ -206,6 +212,14 @@ def clang():
             "http://llvm.org/releases/3.8.0/clang+llvm-3.8.0-x86_64-apple-darwin.tar.xz",
         ],
         macos_sha256 = "e5a961e04b0e1738bbb5b824886a34932dc13b0af699d1fe16519d814d7b776f",
+    )
+
+def bazel_skylib():
+    http_archive(
+        name = "bazel_skylib",
+        sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
+        strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
     )
 
 def com_google_auto_common():
@@ -970,4 +984,18 @@ def phantomjs():
             "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-macosx.zip",
         ],
         macos_sha256 = "538cf488219ab27e309eafc629e2bcee9976990fe90b1ec334f541779150f8c1",
+    )
+
+def zlib():
+    http_archive(
+        name = "net_zlib",
+        build_file = "@io_bazel_rules_closure//:third_party/zlib.BUILD",
+        sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
+        strip_prefix = "zlib-1.2.11",
+        urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
+    )
+
+    native.bind(
+        name = "zlib",
+        actual = "@net_zlib//:zlib",
     )


### PR DESCRIPTION
The repository now requires skylib and zlib, since the Protobuf update (#341, #344).