### PR TITLE
Migrate from is(Not)SameAs to is(Not)SameInstanceAs.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,11 +89,11 @@ java_import_external(
 
 java_import_external(
     name = "com_google_truth",
-    jar_sha256 = "dd652bdf0c4427c59848ac0340fd6b6d20c2cbfaa3c569a8366604dbcda5214c",
+    jar_sha256 = "a9e6796786c9c77a5fe19b08e72fe0a620d53166df423d8861af9ebef4dc4247",
     jar_urls = [
-        "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/truth/truth/0.42/truth-0.42.jar",
-        "http://repo1.maven.org/maven2/com/google/truth/truth/0.42/truth-0.42.jar",
-        "http://maven.ibiblio.org/maven2/com/google/truth/truth/0.42/truth-0.42.jar",
+        "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/truth/truth/0.44/truth-0.44.jar",
+        "http://repo1.maven.org/maven2/com/google/truth/truth/0.44/truth-0.44.jar",
+        "http://maven.ibiblio.org/maven2/com/google/truth/truth/0.44/truth-0.44.jar",
     ],
     licenses = ["notice"],  # Apache 2.0
     testonly_ = 1,

--- a/javatests/io/bazel/rules/closure/WebpathTest.java
+++ b/javatests/io/bazel/rules/closure/WebpathTest.java
@@ -179,15 +179,15 @@ public class WebpathTest {
   @Test
   public void testNormalize_outputIsEqual_newObjectIsntCreated() {
     Webpath path = wp("/hi/there");
-    assertThat(path.normalize()).isSameAs(path);
+    assertThat(path.normalize()).isSameInstanceAs(path);
     path = wp("/hi/there/");
-    assertThat(path.normalize()).isSameAs(path);
+    assertThat(path.normalize()).isSameInstanceAs(path);
     path = wp("../");
-    assertThat(path.normalize()).isSameAs(path);
+    assertThat(path.normalize()).isSameInstanceAs(path);
     path = wp("../..");
-    assertThat(path.normalize()).isSameAs(path);
+    assertThat(path.normalize()).isSameInstanceAs(path);
     path = wp("./");
-    assertThat(path.normalize()).isSameAs(path);
+    assertThat(path.normalize()).isSameInstanceAs(path);
   }
 
   @Test
@@ -211,8 +211,8 @@ public class WebpathTest {
   @Test
   public void testResolve_sameObjectOptimization() {
     Webpath path = wp("/hi/there");
-    assertThat(path.resolve(wp(""))).isSameAs(path);
-    assertThat(wp("hello").resolve(path)).isSameAs(path);
+    assertThat(path.resolve(wp(""))).isSameInstanceAs(path);
+    assertThat(wp("hello").resolve(path)).isSameInstanceAs(path);
   }
 
   @Test
@@ -641,14 +641,14 @@ public class WebpathTest {
   @Test
   public void testInterner_producesIdenticalInstances() throws Exception {
     WebpathInterner interner = new WebpathInterner();
-    assertThat(interner.get("foo")).isSameAs(interner.get("foo"));
+    assertThat(interner.get("foo")).isSameInstanceAs(interner.get("foo"));
   }
 
   @Test
   public void testInterner_supportsFunctionalProgramming_forGreatJustice() throws Exception {
     WebpathInterner interner = new WebpathInterner();
     List<Webpath> dubs = Lists.transform(ImmutableList.of("foo", "foo"), interner);
-    assertThat(dubs.get(0)).isSameAs(dubs.get(1));
+    assertThat(dubs.get(0)).isSameInstanceAs(dubs.get(1));
   }
 
   @Test


### PR DESCRIPTION
They behave identically, and the old names are being removed.

The new methods are available in Truth as of version 0.44, so update Truth to that version.