### PR TITLE
Migrate users from the old, deprecated Subject.fail* methods to the new Subject.fail* methods or, in some cases, to Subject.check.

### DIFF
--- a/javatests/io/bazel/rules/closure/worker/testing/ProgramResult.java
+++ b/javatests/io/bazel/rules/closure/worker/testing/ProgramResult.java
@@ -88,7 +88,7 @@ public abstract class ProgramResult {
     @Override
     public WarningsChain succeeded() {
       if (actual().failed() || !actual().errors().isEmpty()) {
-        fail("was a successful web action invocation");
+        failWithActual(simpleFact("expected to be a successful web action invocation"));
       }
       return this;
     }
@@ -96,33 +96,25 @@ public abstract class ProgramResult {
     @Override
     public WarningsChain withErrors(String... warnings) {
       checkArgument(warnings.length > 0);
-      if (actual().warnings().isEmpty()) {
-        fail("contained warnings");
-      }
       check("warnings()")
-               .that(actual().warnings())
-               .containsExactly(Arrays.asList(warnings))
-               .inOrder();
+          .that(actual().warnings())
+          .containsExactly(Arrays.asList(warnings))
+          .inOrder();
       return this;
     }
 
     @Override
     public void withoutWarnings() {
-      if (!actual().warnings().isEmpty()) {
-        fail("had an empty output without warnings");
-      }
+      check("warnings()").that(actual().warnings()).isEmpty();
     }
 
     @Override
     public void withWarnings(String... warnings) {
       checkArgument(warnings.length > 0);
-      if (actual().warnings().isEmpty()) {
-        fail("contained warnings");
-      }
       check("warnings()")
-                .that(actual().warnings())
-                .containsExactly(Arrays.asList(warnings))
-                .inOrder();
+          .that(actual().warnings())
+          .containsExactly(Arrays.asList(warnings))
+          .inOrder();
     }
   }
 


### PR DESCRIPTION
This changes the format of the message, but all the information should still be there.