### PR TITLE
Expose extern zip file from js compiler jar.

### DIFF
--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -374,7 +374,6 @@ def com_google_closure_stylesheets():
             "    output_licenses = [\"unencumbered\"],",
             "    runtime_deps = [\":com_google_closure_stylesheets\"],",
             ")",
-            "", 
         ]),
     )
 

--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -374,6 +374,7 @@ def com_google_closure_stylesheets():
             "    output_licenses = [\"unencumbered\"],",
             "    runtime_deps = [\":com_google_closure_stylesheets\"],",
             ")",
+            "", 
         ]),
     )
 
@@ -635,12 +636,14 @@ def com_google_java_format():
     )
 
 def com_google_javascript_closure_compiler():
+    version = "v20190325"
+    jar = "closure-compiler-unshaded-%s.jar" % version
     java_import_external(
         name = "com_google_javascript_closure_compiler",
         licenses = ["reciprocal"],  # MPL v1.1 (Rhino AST), Apache 2.0 (JSCompiler)
         jar_urls = [
-            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/javascript/closure-compiler-unshaded/v20190325/closure-compiler-unshaded-v20190325.jar",
-            "http://repo1.maven.org/maven2/com/google/javascript/closure-compiler-unshaded/v20190325/closure-compiler-unshaded-v20190325.jar",
+            "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/javascript/closure-compiler-unshaded/%s/%s" % (version, jar),
+            "http://repo1.maven.org/maven2/com/google/javascript/closure-compiler-unshaded/%s/%s" % (version, jar),
         ],
         jar_sha256 = "ae9ed32b24f59a4d412efb7196618c592cb23469d81103a4bec3c7cdd81dfe67",
         deps = [
@@ -659,6 +662,15 @@ def com_google_javascript_closure_compiler():
             "        \"@args4j\",",
             "    ],",
             ")",
+            "",
+            "genrule(",
+            "    name = \"externs\",",
+            "    srcs = [\"%s\"]," % jar,
+            "    outs = [\"externs.zip\"],",
+            "    tools = [\"@bazel_tools//tools/jdk:jar\"],",
+            "    cmd = \"$(location @bazel_tools//tools/jdk:jar) -xf $(location :%s) externs.zip; cp externs.zip $@\"," % jar,
+            ")",
+            "",
         ]),
     )
 


### PR DESCRIPTION
Add a Bazel rule for exposing zip file containing extern files used by the js compiler so tools depending on this repository can refer them.