### PR TITLE
Fix error reporting

### DIFF
--- a/closure/compiler/closure_js_binary.bzl
+++ b/closure/compiler/closure_js_binary.bzl
@@ -42,7 +42,7 @@ def _impl(ctx):
     if ctx.attr.language not in JS_LANGUAGES.to_list():
         fail("Unknown language %s try one of these: %s" % (
             ctx.attr.language,
-            ", ".join(JS_LANGUAGES),
+            ", ".join(JS_LANGUAGES.to_list()),
         ))
 
     deps = unfurl(ctx.attr.deps, provider = "closure_js_library")


### PR DESCRIPTION
```
Traceback (most recent call last):
	File "/xxx/BUILD", line 117
		closure_js_binary(name = 'yyy')
	File "/private/var/tmp/_bazel_zzz/uuu/external/io_bazel_rules_closure/closure/compiler/closure_js_binary.bzl", line 43, in _impl
		fail(("Unknown language %s try one of...))))
	File "/private/var/tmp/_bazel_eustas/uuu/external/io_bazel_rules_closure/closure/compiler/closure_js_binary.bzl", line 45, in fail
		", ".join(JS_LANGUAGES)
expected value of type 'sequence' for parameter 'elements', for call to method join(elements) of 'string'
```