### PR TITLE
Extend raw Subject instead of supplying type parameters.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,11 +89,11 @@ java_import_external(
 
 java_import_external(
     name = "com_google_truth",
-    jar_sha256 = "a9e6796786c9c77a5fe19b08e72fe0a620d53166df423d8861af9ebef4dc4247",
+    jar_sha256 = "0f7dced2a16e55a77e44fc3ff9c5be98d4bf4bb30abc18d78ffd735df950a69f",
     jar_urls = [
-        "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/truth/truth/0.44/truth-0.44.jar",
-        "http://repo1.maven.org/maven2/com/google/truth/truth/0.44/truth-0.44.jar",
-        "http://maven.ibiblio.org/maven2/com/google/truth/truth/0.44/truth-0.44.jar",
+        "https://mirror.bazel.build/repo1.maven.org/maven2/com/google/truth/truth/0.45/truth-0.45.jar",
+        "http://repo1.maven.org/maven2/com/google/truth/truth/0.45/truth-0.45.jar",
+        "http://maven.ibiblio.org/maven2/com/google/truth/truth/0.45/truth-0.45.jar",
     ],
     licenses = ["notice"],  # Apache 2.0
     testonly_ = 1,

--- a/javatests/io/bazel/rules/closure/WebpathTest.java
+++ b/javatests/io/bazel/rules/closure/WebpathTest.java
@@ -26,7 +26,6 @@ import com.google.common.jimfs.Jimfs;
 import com.google.common.testing.EqualsTester;
 import com.google.common.testing.NullPointerTester;
 import com.google.common.truth.BooleanSubject;
-import com.google.common.truth.DefaultSubject;
 import com.google.common.truth.IterableSubject;
 import com.google.common.truth.Subject;
 import com.google.common.truth.Truth;
@@ -62,7 +61,7 @@ public class WebpathTest {
   }
 
   // Workaround fact that Path interface matches multiple assertThat() method overloads.
-  private static Subject<DefaultSubject, Object> assertThat(Object subject) {
+  private static Subject assertThat(Object subject) {
     return Truth.assertThat(subject);
   }
 

--- a/javatests/io/bazel/rules/closure/worker/testing/ProgramResult.java
+++ b/javatests/io/bazel/rules/closure/worker/testing/ProgramResult.java
@@ -69,8 +69,7 @@ public abstract class ProgramResult {
     WarningsChain withErrors(String... warnings);
   }
 
-  private static final class ProgramResultSubject
-      extends Subject<ProgramResultSubject, ProgramResult>
+  private static final class ProgramResultSubject extends Subject
       implements ResultChain, WarningsChain, FailedChain {
 
     private final ProgramResult actual;


### PR DESCRIPTION
The type parameters are being removed from Subject.

Also, update to Truth 0.45, which makes this change possible by loosening the type parameters on Subject.Factory.