### PR TITLE
closure_js_template_library: add `defs` attr as a pass-through to SoyToJsSrcCompiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,10 +551,10 @@ This rule can be referenced as though it were the following:
 load("@io_bazel_rules_closure//closure:defs.bzl", "closure_js_template_library")
 closure_js_template_library(name, srcs, data, deps, globals, plugin_modules,
                             should_generate_js_doc,
-                            should_provide_require_soy_namespaces,
                             should_generate_soy_msg_defs,
                             bidi_global_dir,
-                            soy_msgs_are_external)
+                            soy_msgs_are_external,
+                            defs)
 ```
 
 Compiles Closure templates to JavaScript source files.
@@ -619,9 +619,6 @@ This rule can be referenced as though it were the following:
 - **should_generate_js_doc:** (Boolean; optional; default is `True`) Passed
   along verbatim to the SoyToJsSrcCompiler above.
 
-- **should_provide_require_soy_namespaces:** (Boolean; optional; default is
-  `True`) Passed along verbatim to the SoyToJsSrcCompiler above.
-
 - **should_generate_soy_msg_defs:** (Boolean; optional; default is `False`)
   Passed along verbatim to the SoyToJsSrcCompiler above.
 
@@ -631,6 +628,9 @@ This rule can be referenced as though it were the following:
 
 - **soy_msgs_are_external:** (Boolean; optional; default is `False`) Passed
   along verbatim to the SoyToJsSrcCompiler above.
+
+- **defs:** (List of strings; optional) Passed along verbatim to the
+  SoyToJsSrcCompiler above.
 
 ## closure\_java\_template\_library
 

--- a/closure/templates/closure_js_template_library.bzl
+++ b/closure/templates/closure_js_template_library.bzl
@@ -32,6 +32,10 @@ def _impl(ctx):
         args += ["--bidiGlobalDir=%s" % ctx.attr.bidi_global_dir]
     if ctx.attr.plugin_modules:
         args += ["--pluginModules=%s" % ",".join(ctx.attr.plugin_modules)]
+    for arg in ctx.attr.defs:
+        if not arg.startswith("--") or (" " in arg and "=" not in arg):
+            fail("Please use --flag=value syntax for defs")
+        args += [arg]
     inputs = []
     for f in ctx.files.srcs:
         args.append("--srcs=" + f.path)
@@ -66,11 +70,11 @@ _closure_js_template_library = rule(
         "outputs": attr.output_list(),
         "globals": attr.label(allow_single_file = True),
         "plugin_modules": attr.label_list(),
-        "should_provide_require_soy_namespaces": attr.bool(default = True),
         "should_generate_soy_msg_defs": attr.bool(),
         "bidi_global_dir": attr.int(default = 1, values = [1, -1]),
         "soy_msgs_are_external": attr.bool(),
         "compiler": attr.label(cfg = "host", executable = True, mandatory = True),
+        "defs": attr.string_list(),
     },
 )
 
@@ -82,10 +86,10 @@ def closure_js_template_library(
         testonly = None,
         globals = None,
         plugin_modules = None,
-        should_provide_require_soy_namespaces = None,
         should_generate_soy_msg_defs = None,
         bidi_global_dir = None,
         soy_msgs_are_external = None,
+        defs = [],
         **kwargs):
     compiler = str(Label(_SOYTOJSSRCCOMPILER))
     js_srcs = [src + ".js" for src in srcs]
@@ -98,11 +102,11 @@ def closure_js_template_library(
         visibility = ["//visibility:private"],
         globals = globals,
         plugin_modules = plugin_modules,
-        should_provide_require_soy_namespaces = should_provide_require_soy_namespaces,
         should_generate_soy_msg_defs = should_generate_soy_msg_defs,
         bidi_global_dir = bidi_global_dir,
         soy_msgs_are_external = soy_msgs_are_external,
         compiler = compiler,
+        defs = defs,
     )
 
     deps = deps + [

--- a/closure/templates/test/BUILD
+++ b/closure/templates/test/BUILD
@@ -57,6 +57,21 @@ file_test(
 )
 
 closure_js_template_library(
+    name = "localized_using_defs_soy",
+    srcs = ["defs.soy"],
+    defs = [
+        "--shouldGenerateGoogMsgDefs=true",
+    ],
+)
+
+file_test(
+    name = "localized_using_defs_test",
+    size = "small",
+    file = ":defs.soy.js",
+    regexp = "goog.getMsg('Hello",
+)
+
+closure_js_template_library(
     name = "greeter_proto_soy",
     srcs = ["greeter_proto.soy"],
     deps = [":person_proto"],

--- a/closure/templates/test/defs.soy
+++ b/closure/templates/test/defs.soy
@@ -1,0 +1,25 @@
+// Copyright 2019 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+{namespace io.bazel.rules.closure.soy.defs}
+
+
+/**
+ * Greets a person.
+ */
+{template .greetLocalizedUsingDefs}
+  {@param name: string}
+  <p>
+    {msg desc="salutation"}Hello <b>{$name}</b>!{/msg}
+{/template}


### PR DESCRIPTION
This also removes the vestigial `should_provide_require_soy_namespaces`

Fixes #381