### PR TITLE
Deprecate closure_repositories in favor of rules_closure_{dependencies,toolchains}

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,17 +2,10 @@ workspace(name = "io_bazel_rules_closure")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//closure/private:java_import_external.bzl", "java_import_external")
-load("//closure:repositories.bzl", "closure_repositories")
 
-closure_repositories()
-
-http_archive(
-    name = "zlib",
-    build_file = "//:third_party/zlib.BUILD",
-    sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-    strip_prefix = "zlib-1.2.11",
-    urls = ["https://zlib.net/zlib-1.2.11.tar.gz"],
-)
+load("@io_bazel_rules_closure//closure:repositories.bzl", "rules_closure_dependencies", "rules_closure_toolchains")
+rules_closure_dependencies()
+rules_closure_toolchains()
 
 http_archive(
     name = "bazel_skylib",

--- a/closure/defs.bzl
+++ b/closure/defs.bzl
@@ -49,6 +49,6 @@ closure_js_template_library = _closure_js_template_library
 closure_js_test = _closure_js_test
 phantomjs_test = _phantomjs_test
 filegroup_external = _filegroup_external
-closure_repositories = _closure_repositories
+closure_repositories = _closure_repositories  # TODO(yannic): Remove on 2019-11-01.
 web_library = _web_library
 web_library_external = _web_library_external

--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -18,7 +18,30 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 load("//closure/private:java_import_external.bzl", "java_import_external")
 load("//closure/private:platform_http_file.bzl", "platform_http_file")
 
-def closure_repositories(
+_ERROR_CLOSURE_REPOSITORIES_IS_DEPRECATED = """
+closure_repositories() is deprecated.
+
+Please add the following to your workspace instead:
+
+  load("@io_bazel_rules_closure//closure:repositories.bzl", "rules_closure_dependencies", "rules_closure_toolchains")
+  rules_closure_dependencies()
+  rules_closure_toolchains()
+""".strip()
+
+def closure_repositories(**kargs):
+    """Legacy macro to import dependencies for Closure Rules."""
+
+    print(_ERROR_CLOSURE_REPOSITORIES_IS_DEPRECATED)
+    rules_closure_dependencies(**kargs)
+
+def rules_closure_toolchains():
+    """An utility method to load all Closure toolchains.
+
+    It doesn't do anything at the moment.
+    """
+    pass
+
+def rules_closure_dependencies(
         omit_aopalliance = False,
         omit_args4j = False,
         omit_bazel_skylib = False,


### PR DESCRIPTION
This PR adds macros to closure/repositories.bzl to make rules_closure
more compliant with Bazel's Style Guide for Rules.

Working towards #421