### PR TITLE
Refactor dependencies consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ http_archive(
     ],
 )
 
-load("@io_bazel_rules_closure//closure:defs.bzl", "closure_repositories")
+load("@io_bazel_rules_closure//closure:deps.bzl", "closure_rules_repositories")
 
-closure_repositories()
+closure_rules_repositories()
 ```
 
 You are not required to install the Closure Tools, PhantomJS, or anything else
@@ -92,23 +92,23 @@ for that matter; they will be fetched automatically by Bazel.
 
 ### Overriding Dependency Versions
 
-When you call `closure_repositories()` in your `WORKSPACE` file, it causes a
+When you call `closure_rules_repositories()` in your `WORKSPACE` file, it causes a
 few dozen external dependencies to be added to your project, e.g. Guava, Guice,
 JSR305, etc. You might need to customize this behavior.
 
 To override the version of any dependency, modify your `WORKSPACE` file to pass
-`omit_<dependency_name>=True` to `closure_repositories()`. Next define your
+`omit_<dependency_name>=True` to `closure_rules_repositories()`. Next define your
 custom dependency version. A full list of dependencies is available from
 [repositories.bzl]. For example, to override the version of Guava:
 
 ```python
 load(
-    "@io_bazel_rules_closure//closure:defs.bzl",
-    "closure_repositories",
+    "@io_bazel_rules_closure//closure:deps.bzl",
+    "closure_rules_repositories",
     "java_import_external",
 )
 
-closure_repositories(
+closure_rules_repositories(
     omit_com_google_guava=True,
 )
 
@@ -1000,5 +1000,5 @@ This rule can be referenced as though it were the following:
 [proto_library]: https://docs.bazel.build/versions/master/be/protocol-buffer.html#proto_library
 [protobuf-generator]: https://github.com/google/protobuf/blob/master/src/google/protobuf/compiler/js/js_generator.h
 [protobuf-js]: https://github.com/google/protobuf/tree/master/js
-[repositories.bzl]: https://github.com/bazelbuild/rules_closure/tree/master/closure/repositories.bzl
+[repositories.bzl]: https://github.com/bazelbuild/rules_closure/tree/master/closure/private/repositories.bzl
 [verbose]: https://github.com/google/closure-library/blob/master/closure/goog/html/safehtml.js

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,9 +2,9 @@ workspace(name = "io_bazel_rules_closure")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//closure/private:java_import_external.bzl", "java_import_external")
-load("//closure:repositories.bzl", "closure_repositories")
+load("//closure:deps.bzl", "closure_rules_dependencies")
 
-closure_repositories()
+closure_rules_dependencies()
 
 http_archive(
     name = "zlib",

--- a/closure/BUILD
+++ b/closure/BUILD
@@ -17,27 +17,6 @@ licenses(["notice"])  # Apache 2.0
 load("//closure/private:lines_sorted_test.bzl", "lines_sorted_test")
 
 lines_sorted_test(
-    name = "repositories_defs_sorted_test",
-    cmd = "sed '1,/BEGIN_DECLARATIONS/ d' $< | grep ^def >$@",
-    error_message = "The functions in repositories.bzl must be sorted",
-    file = "repositories.bzl",
-)
-
-lines_sorted_test(
-    name = "repositories_params_sorted_test",
-    cmd = "grep -e '^ *omit' $< | grep -o 'omit_[_0-9a-z]*' >$@",
-    error_message = "The parameter list in repositories.bzl must be sorted",
-    file = "repositories.bzl",
-)
-
-lines_sorted_test(
-    name = "repositories_calls_sorted_test",
-    cmd = "grep -e '^ *if not omit' $< | grep -o 'omit_[_0-9a-z]*' >$@",
-    error_message = "The param call list in repositories.bzl must be sorted",
-    file = "repositories.bzl",
-)
-
-lines_sorted_test(
     name = "defs_loads_sorted_test",
     cmd = "grep -e '^load' $< >$@",
     error_message = "The load list in defs.bzl must be sorted",

--- a/closure/defs.bzl
+++ b/closure/defs.bzl
@@ -18,7 +18,6 @@ load("//closure/compiler:closure_js_deps.bzl", _closure_js_deps = "closure_js_de
 load("//closure/compiler:closure_js_library.bzl", _closure_js_library = "closure_js_library", _create_closure_js_library = "create_closure_js_library")
 load("//closure/private:defs.bzl", _CLOSURE_JS_TOOLCHAIN_ATTRS = "CLOSURE_JS_TOOLCHAIN_ATTRS")
 load("//closure/private:files_equal_test.bzl", _files_equal_test = "files_equal_test")
-load("//closure/private:java_import_external.bzl", _java_import_external = "java_import_external")
 load("//closure/protobuf:closure_js_proto_library.bzl", _closure_js_proto_library = "closure_js_proto_library")
 load("//closure/protobuf:closure_proto_library.bzl", _closure_proto_library = "closure_proto_library")
 load("//closure/stylesheets:closure_css_binary.bzl", _closure_css_binary = "closure_css_binary")
@@ -28,7 +27,6 @@ load("//closure/templates:closure_js_template_library.bzl", _closure_js_template
 load("//closure/testing:closure_js_test.bzl", _closure_js_test = "closure_js_test")
 load("//closure/testing:phantomjs_test.bzl", _phantomjs_test = "phantomjs_test")
 load("//closure:filegroup_external.bzl", _filegroup_external = "filegroup_external")
-load("//closure:repositories.bzl", _closure_repositories = "closure_repositories")
 load("//closure:webfiles/web_library.bzl", _web_library = "web_library")
 load("//closure:webfiles/web_library_external.bzl", _web_library_external = "web_library_external")
 
@@ -39,7 +37,6 @@ closure_js_library = _closure_js_library
 create_closure_js_library = _create_closure_js_library
 CLOSURE_JS_TOOLCHAIN_ATTRS = _CLOSURE_JS_TOOLCHAIN_ATTRS
 files_equal_test = _files_equal_test
-java_import_external = _java_import_external
 closure_js_proto_library = _closure_js_proto_library
 closure_proto_library = _closure_proto_library
 closure_css_binary = _closure_css_binary
@@ -49,6 +46,8 @@ closure_js_template_library = _closure_js_template_library
 closure_js_test = _closure_js_test
 phantomjs_test = _phantomjs_test
 filegroup_external = _filegroup_external
-closure_repositories = _closure_repositories
 web_library = _web_library
 web_library_external = _web_library_external
+
+def closure_repositories():
+    fail("Consumption of closure_repositories through defs.bzl is discontinued, instead load 'closure_rules_repositories' from '@io_bazel_rules_closure//closure:deps.bzl'.")

--- a/closure/deps.bzl
+++ b/closure/deps.bzl
@@ -1,0 +1,31 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# deps.bzl loads definitions for use in WORKSPACE files. It's important
+# to keep this file and the .bzl files it loads separate from the files
+# loaded by def.bzl. def.bzl and its dependencies may depend on repositories
+# declared here, but at the time this file is loaded, we can't assume
+# anything has been declared.
+
+load(
+    "@io_bazel_rules_closure//closure/private:repositories.bzl",
+    _closure_rules_dependencies = "closure_rules_dependencies",
+)
+load(
+    "//closure/private:java_import_external.bzl",
+     _java_import_external = "java_import_external",
+)
+
+closure_rules_dependencies = _closure_rules_dependencies
+java_import_external = _java_import_external

--- a/closure/private/BUILD
+++ b/closure/private/BUILD
@@ -14,9 +14,32 @@
 
 package(default_visibility = ["//visibility:public"])
 
+load("//closure/private:lines_sorted_test.bzl", "lines_sorted_test")
+
 licenses(["notice"])  # Apache 2.0
 
 sh_binary(
     name = "gensrcjar",
     srcs = ["gensrcjar.sh"],
+)
+
+lines_sorted_test(
+    name = "repositories_defs_sorted_test",
+    cmd = "sed '1,/BEGIN_DECLARATIONS/ d' $< | grep ^def >$@",
+    error_message = "The functions in repositories.bzl must be sorted",
+    file = "repositories.bzl",
+)
+
+lines_sorted_test(
+    name = "repositories_params_sorted_test",
+    cmd = "grep -e '^ *omit' $< | grep -o 'omit_[_0-9a-z]*' >$@",
+    error_message = "The parameter list in repositories.bzl must be sorted",
+    file = "repositories.bzl",
+)
+
+lines_sorted_test(
+    name = "repositories_calls_sorted_test",
+    cmd = "grep -e '^ *if not omit' $< | grep -o 'omit_[_0-9a-z]*' >$@",
+    error_message = "The param call list in repositories.bzl must be sorted",
+    file = "repositories.bzl",
 )

--- a/closure/private/repositories.bzl
+++ b/closure/private/repositories.bzl
@@ -18,7 +18,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file"
 load("//closure/private:java_import_external.bzl", "java_import_external")
 load("//closure/private:platform_http_file.bzl", "platform_http_file")
 
-def closure_repositories(
+def closure_rules_dependencies(
         omit_aopalliance = False,
         omit_args4j = False,
         omit_bazel_skylib = False,


### PR DESCRIPTION
Extract dependencies definition from defs.bzl. This is conform to the
deploying rules guide: [1] and also a preparation to consume the proto,
python and java rules from Starlak.

Add a deprecation message in closure_repositories macro, when it is
still consumed form defs.bzl file. Consider to remove this deprecation
message when a new release is cut.

[1] https://docs.bazel.build/versions/master/skylark/deploying.html