### PR TITLE
Check in dummy base.js.i.js declaring goog for library-level typechecking

### DIFF
--- a/closure/compiler/closure_js_library.bzl
+++ b/closure/compiler/closure_js_library.bzl
@@ -110,6 +110,7 @@ def _closure_js_library_impl(
         internal_descriptors = depset(),
         no_closure_library = False,
         internal_expect_failure = False,
+        fake_base_ijs = [],
 
         # These file definitions for our outputs are deprecated,
         # and will be replaced with |actions.declare_file()| soon.
@@ -304,6 +305,7 @@ def _closure_js_library_impl(
         ),
         suppress = suppress,
         internal_expect_failure = internal_expect_failure,
+        fake_base_ijs = fake_base_ijs,
     )
 
     if type(internal_descriptors) == "list":
@@ -412,6 +414,7 @@ def _closure_js_library(ctx):
         ctx.files.internal_descriptors,
         ctx.attr.no_closure_library,
         ctx.attr.internal_expect_failure,
+        ctx.files._fake_base_ijs,
 
         # Deprecated output files.
         ctx.outputs.info,

--- a/closure/private/BUILD
+++ b/closure/private/BUILD
@@ -16,6 +16,8 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
+exports_files(["base.js.i.js"])
+
 sh_binary(
     name = "gensrcjar",
     srcs = ["gensrcjar.sh"],

--- a/closure/private/base.js.i.js
+++ b/closure/private/base.js.i.js
@@ -1,0 +1,4 @@
+/** @provideGoog */  // IJS[closure/base.js]
+/** @fileoverview @typeSummary */
+/** @define {boolean} */ var COMPILED;
+/** @const */ var goog = {};

--- a/closure/private/defs.bzl
+++ b/closure/private/defs.bzl
@@ -46,6 +46,11 @@ CLOSURE_LIBRARY_BASE_ATTR = attr.label(
     allow_files = True,
 )
 
+FAKE_BASE_IJS_ATTR = attr.label(
+    default = Label("//closure/private:base.js.i.js"),
+    allow_single_file = True,
+)
+
 CLOSURE_WORKER_ATTR = attr.label(
     default = Label("//java/io/bazel/rules/closure:ClosureWorker"),
     executable = True,
@@ -53,6 +58,7 @@ CLOSURE_WORKER_ATTR = attr.label(
 )
 
 CLOSURE_JS_TOOLCHAIN_ATTRS = {
+    "_fake_base_ijs": FAKE_BASE_IJS_ATTR,
     "_closure_library_base": CLOSURE_LIBRARY_BASE_ATTR,
     "_ClosureWorker": CLOSURE_WORKER_ATTR,
 }
@@ -255,7 +261,8 @@ def library_level_checks(
         executable,
         output,
         suppress = [],
-        internal_expect_failure = False):
+        internal_expect_failure = False,
+        fake_base_ijs = []):
     args = [
         "JsCompiler",
         "--checks_only",
@@ -271,7 +278,7 @@ def library_level_checks(
         output.path,
     ]
     inputs = []
-    for f in ijs_deps.to_list():
+    for f in fake_base_ijs + ijs_deps.to_list():
         args.append("--externs=%s" % f.path)
         inputs.append(f)
 


### PR DESCRIPTION
Proposed workaround for https://github.com/bazelbuild/rules_closure/issues/426