### PR TITLE
Suppress deprecated on soy generated code.

### DIFF
--- a/closure/templates/closure_js_template_library.bzl
+++ b/closure/templates/closure_js_template_library.bzl
@@ -139,6 +139,7 @@ def closure_js_template_library(
         testonly = testonly,
         suppress = suppress + [
             "analyzerChecks",
+            "deprecated",
             "reportUnknownTypes",
             "strictCheckTypes",
             "unusedLocalVariables",


### PR DESCRIPTION
User doesn't have control over these so it doesn't make
sense to have it enabled by default.

In the latest closure library release some method will be deprecated
and will cause breakage in most closure template targets without this
fix.