### PR TITLE
Inclusion of "*.css.js" css name mapping as the output files of closure_css_binary

### DIFF
--- a/closure/stylesheets/closure_css_binary.bzl
+++ b/closure/stylesheets/closure_css_binary.bzl
@@ -78,7 +78,7 @@ def _closure_css_binary(ctx):
         ),
     )
     return struct(
-        files = depset(files),
+        files = depset(outputs),
         closure_css_binary = struct(
             bin = ctx.outputs.bin,
             map = ctx.outputs.map,


### PR DESCRIPTION
# Problem Statement

`closure/stylesheets/closure_css_binary.bzl` declares `%{name}.css.js` as its output : 
```
outputs = {
        "bin": "%{name}.css",
        "map": "%{name}.css.map",
        "js": "%{name}.css.js",
    },
```

however, the returned `struct`'s `files` list was `files` which did not include `ctx.outputs.js` :

```
...
if not css.srcs:
        fail("There are no CSS source files in the transitive closure")
    inputs = []
    files = [ctx.outputs.bin, ctx.outputs.map]
...
return struct(
        files = depset(files),
        closure_css_binary = struct(
            bin = ctx.outputs.bin,
...
```

By changing `depset(files)` to `depset(output)` we have the artifact included when it's built.


# My specific use case for which this is a solution

I have a _Macro_ for a genrule which takes `:js_bin`, `:css_bin`, etc. as input, and creates a copy of the input files with the exact same extensions, but with the name provided to the macro.

An example renaming : 

```
expose_as(
    name = "options",
    srcs = [
       ":js_bin",
       ":css_bin",
       ":html_bin"
    ],
    visibility = BINARY_BUILD_VISIBILITY
)
```

| Original name   | Renamed / Copied name |
|-----------------|-----------------------|
| js_bin.js       | options.js            |
| js_bin.js.map   | options.js.map        |
| css_bin.css     | options.css           |
| css_bin.css.map | options.css.map       |
| css_bin.css.js  | options.css.js        |
| ...             | ...                   |

Since `%{name}.css.js` wasn't part of the actual outputs, it failed.
With this fix it works, and **to the best of my knowledge** it shouldn't break any existing behavior, and isn't a flawed expression of intent either.

If it's problematic, sorry for the inconvenience, and I'll attempt to find a work-around.