### PR TITLE
export third_party/zlib.BUILD to allow imports

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -13,3 +13,5 @@
 # limitations under the License.
 
 package(default_visibility = ["//visibility:public"])
+
+exports_files(["zlib.BUILD"])


### PR DESCRIPTION
When importing dependencies of `zlib` with `closure_repositories`

```bzl
load("@io_bazel_rules_closure//closure:defs.bzl", "closure_repositories")

closure_repositories()
```

It currently gives an error because the associated build files are not exported:

```plaintext
ERROR: /var/lib/jenkins/.cache/bazel/_bazel_jenkins/de8446692c11da2ee9ac26006b0c07ab/external/io_bazel_rules_closure/closure/repositories.bzl:1003:5: no such target '@io_bazel_rules_closure//:third_party/zlib.BUILD': target 'third_party/zlib.BUILD' not declared in package ''; however, a source file of this name exists.  (Perhaps add 'exports_files(["third_party/zlib.BUILD"])' to /BUILD?) defined by /var/lib/jenkins/.cache/bazel/_bazel_jenkins/de8446692c11da2ee9ac26006b0c07ab/external/io_bazel_rules_closure/BUILD and referenced by '//external:zlib'
```

This PR exports the build file so they can be accessible by external consumers.