### PR TITLE
Protobuf: Remove java 7 compatibility mode

### DIFF
--- a/closure/protobuf_drop_java_7_compatibility.patch
+++ b/closure/protobuf_drop_java_7_compatibility.patch
@@ -1,0 +1,39 @@
+diff --git a/BUILD b/BUILD.bazel
+index efc3d8e..2f27833 100644
+--- a/BUILD
++++ b/BUILD.bazel
+@@ -653,10 +653,7 @@ java_library(
+     ],
+     javacopts = select({
+         "//:jdk9": ["--add-modules=jdk.unsupported"],
+-        "//conditions:default": [
+-            "-source 7",
+-            "-target 7",
+-        ],
++        "//conditions:default": [],
+     }),
+     visibility = ["//visibility:public"],
+ )
+@@ -754,10 +751,7 @@ java_library(
+     ],
+     javacopts = select({
+         "//:jdk9": ["--add-modules=jdk.unsupported"],
+-        "//conditions:default": [
+-            "-source 7",
+-            "-target 7",
+-        ],
++        "//conditions:default": [],
+     }),
+     visibility = ["//visibility:public"],
+ )
+@@ -767,10 +761,6 @@ java_library(
+     srcs = glob([
+         "java/util/src/main/java/com/google/protobuf/util/*.java",
+     ]),
+-    javacopts = [
+-        "-source 7",
+-        "-target 7",
+-    ],
+     visibility = ["//visibility:public"],
+     deps = [
+         "protobuf_java",

--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -738,6 +738,10 @@ def com_google_jsinterop_annotations():
 def com_google_protobuf():
     http_archive(
         name = "com_google_protobuf",
+        patches = [
+            "@io_bazel_rules_closure//closure:protobuf_drop_java_7_compatibility.patch",
+        ],
+        patch_args = ["-p1"],
         strip_prefix = "protobuf-3.10.0",
         sha256 = "758249b537abba2f21ebc2d02555bf080917f0f2f88f4cbe2903e0e28c4187ed",
         urls = [


### PR DESCRIPTION
This is a workaround to suppress this annoying warning:

  warning: -parameters is not supported for target value 1.7. Use 1.8 or later.

wenn building protobuf_java. The full story can be seen in this Bazel
issue: [1]. I tried hard to avoid the need for patching Protobuf on
fetch, by trying to remove Java 7 compatibility mode upstream, that was
rejected: [2]. Moreover, I tried hard and spent quite some time to fix
the problem in Bazel: [3], in non-invasive way, but this PR was as well
rejected. The next natural approach is to just patch the Protobuf source
during the fetch operation.

Needless to say, that the patching during the fetch has its own
disavdantages, that the patch would probably need to be updated on
every Protobuf upgrade. But what can you do? The developers are
complaining and filling the issues in every issue tracker, as here in
Gerrit Code Review project: [4].

[1] https://github.com/bazelbuild/bazel/issues/8772
[3] https://github.com/bazelbuild/bazel/pull/9494
[3] https://github.com/protocolbuffers/protobuf/pull/6711
[4] https://bugs.chromium.org/p/gerrit/issues/detail?id=11102