### PR TITLE
Fix unfurl to add an extra level of indirection

### DIFF
--- a/closure/private/defs.bzl
+++ b/closure/private/defs.bzl
@@ -76,6 +76,13 @@ def unfurl(deps, provider = ""):
             for edep in dep.exports:
                 if not provider or hasattr(edep, provider):
                     res.append(edep)
+                # NOTE: This is really bad, but now that Closure Library uses
+                # an extra level of indirection, we kind of need it until
+                # somebody fixes it the right way.
+                if hasattr(edep, "exports"):
+                    for eedep in edep.exports:
+                        if not provider or hasattr(eedep, provider):
+                            res.append(eedep)
     return res
 
 def collect_js(


### PR DESCRIPTION
As currently implemented, rules_closure's "strict deps checking" is inaccurate.  It recurses one level of exports and only ensures that the dep is included by something somewhere.  Recent refactoring has added an extra level of indirection to Closure Library internally, which causes this check to fail without the extra layer.  Starlark does not allow recursive function calls, so the quickest workaround is to add one more level of unfurling.  A better long-term fix would be to use a proper depset here.