### PR TITLE
drop CheckMissingAndExtraRequires

### DIFF
--- a/java/com/google/javascript/jscomp/JsCheckerPassConfig.java
+++ b/java/com/google/javascript/jscomp/JsCheckerPassConfig.java
@@ -94,8 +94,6 @@ final class JsCheckerPassConfig extends PassConfig.PassConfigDelegate {
                         new CheckPrimitiveAsObject(compiler),
                         new CheckProvidesSorted(CheckProvidesSorted.Mode.COLLECT_AND_REPORT),
                         new CheckRequiresSorted(CheckRequiresSorted.Mode.COLLECT_AND_REPORT),
-                        new CheckMissingAndExtraRequires(
-                            compiler, CheckMissingAndExtraRequires.Mode.SINGLE_FILE),
                         new CheckUnusedLabels(compiler),
                         new CheckUselessBlocks(compiler),
                         new ClosureCheckModule(compiler, compiler.getModuleMetadataMap()),


### PR DESCRIPTION
This check cannot work properly in single-file mode, so we are dropping
support for calling it in single-file mode.