### PR TITLE
Loosen the test on goog.dom dependency

### DIFF
--- a/closure/compiler/test/closure_js_deps/BUILD
+++ b/closure/compiler/test/closure_js_deps/BUILD
@@ -77,7 +77,7 @@ file_test(
 file_test(
     name = "googDomDependency_includesClosureLibraryStuffInDepsFile",
     file = "goblin_deps.js",
-    regexp = "^goog.addDependency('\\./dom/dom\\.js', \\['goog\\.dom'",
+    regexp = "^goog.addDependency('.*/dom/dom\\.js', \\['goog\\.dom'",
 )
 
 file_test(


### PR DESCRIPTION
This allows moving the file around a bit without breaking the test.