### PR TITLE
Suppress lintChecks on libraries using goog.provide

### DIFF
--- a/closure/compiler/test/closure_js_deps/BUILD
+++ b/closure/compiler/test/closure_js_deps/BUILD
@@ -43,6 +43,7 @@ closure_js_library(
     name = "hyperion_lib",
     srcs = ["hyperion.js"],
     data = ["data1.txt"],
+    suppress = ["lintChecks"],  # use of goog.provide
     deps = [":external_library"],
 )
 
@@ -94,6 +95,7 @@ closure_js_library(
     name = "hyperion2_lib",
     srcs = ["hyperion2.js"],
     data = ["data2.txt"],
+    suppress = ["lintChecks"],  # use of goog.provide
     deps = [":hyperion_lib"],
 )
 

--- a/closure/compiler/test/closure_js_deps/BUILD
+++ b/closure/compiler/test/closure_js_deps/BUILD
@@ -43,7 +43,10 @@ closure_js_library(
     name = "hyperion_lib",
     srcs = ["hyperion.js"],
     data = ["data1.txt"],
-    suppress = ["lintChecks"],  # use of goog.provide
+    suppress = [
+        "lintChecks",
+        "superfluousSuppress",
+    ],  # use of goog.provide
     deps = [":external_library"],
 )
 
@@ -95,7 +98,10 @@ closure_js_library(
     name = "hyperion2_lib",
     srcs = ["hyperion2.js"],
     data = ["data2.txt"],
-    suppress = ["lintChecks"],  # use of goog.provide
+    suppress = [
+        "lintChecks",
+        "superfluousSuppress",
+    ],  # use of goog.provide
     deps = [":hyperion_lib"],
 )
 

--- a/closure/compiler/test/exports_and_entry_points/BUILD
+++ b/closure/compiler/test/exports_and_entry_points/BUILD
@@ -83,6 +83,7 @@ file_test(
 closure_js_library(
     name = "library_goog_lib",
     srcs = ["library_goog.js"],
+    suppress = ["lintChecks"],  # use of goog.provide
 )
 
 closure_js_binary(

--- a/closure/compiler/test/exports_and_entry_points/BUILD
+++ b/closure/compiler/test/exports_and_entry_points/BUILD
@@ -83,7 +83,10 @@ file_test(
 closure_js_library(
     name = "library_goog_lib",
     srcs = ["library_goog.js"],
-    suppress = ["lintChecks"],  # use of goog.provide
+    suppress = [
+        "lintChecks",
+        "superfluousSuppress",
+    ],  # use of goog.provide
 )
 
 closure_js_binary(

--- a/closure/compiler/test/strict_dependency_checking/BUILD
+++ b/closure/compiler/test/strict_dependency_checking/BUILD
@@ -25,17 +25,20 @@ load("//closure:defs.bzl", "closure_js_binary", "closure_js_library")
 closure_js_library(
     name = "a",
     srcs = ["a.js"],
+    suppress = ["lintChecks"],  # use of goog.provide
 )
 
 closure_js_library(
     name = "b",
     srcs = ["b.js"],
+    suppress = ["lintChecks"],  # use of goog.provide
     deps = [":a"],
 )
 
 closure_js_library(
     name = "c",
     srcs = ["c.js"],
+    suppress = ["lintChecks"],  # use of goog.provide
     deps = [
         ":a",
         ":b",
@@ -46,6 +49,7 @@ closure_js_library(
     name = "t",
     testonly = True,
     srcs = ["t.js"],
+    suppress = ["lintChecks"],  # use of goog.provide
 )
 
 file_test(
@@ -95,6 +99,7 @@ file_test(
 closure_js_library(
     name = "b2",
     srcs = ["b.js"],
+    suppress = ["lintChecks"],  # use of goog.provide
     exports = [":a"],
     deps = [":a"],
 )
@@ -102,6 +107,7 @@ closure_js_library(
 closure_js_library(
     name = "exportMadeTransitiveDepDirect",
     srcs = ["c.js"],
+    suppress = ["lintChecks"],  # use of goog.provide
     deps = [":b2"],  # but if :b exports :a, then we're ok
 )
 
@@ -211,6 +217,7 @@ closure_js_library(
         "a.js",
         "es6_a.js",
     ],
+    suppress = ["lintChecks"],  # use of goog.provide
 )
 
 file_test(

--- a/closure/compiler/test/strict_dependency_checking/BUILD
+++ b/closure/compiler/test/strict_dependency_checking/BUILD
@@ -25,20 +25,29 @@ load("//closure:defs.bzl", "closure_js_binary", "closure_js_library")
 closure_js_library(
     name = "a",
     srcs = ["a.js"],
-    suppress = ["lintChecks"],  # use of goog.provide
+    suppress = [
+        "lintChecks",
+        "superfluousSuppress",
+    ],  # use of goog.provide
 )
 
 closure_js_library(
     name = "b",
     srcs = ["b.js"],
-    suppress = ["lintChecks"],  # use of goog.provide
+    suppress = [
+        "lintChecks",
+        "superfluousSuppress",
+    ],  # use of goog.provide
     deps = [":a"],
 )
 
 closure_js_library(
     name = "c",
     srcs = ["c.js"],
-    suppress = ["lintChecks"],  # use of goog.provide
+    suppress = [
+        "lintChecks",
+        "superfluousSuppress",
+    ],  # use of goog.provide
     deps = [
         ":a",
         ":b",
@@ -49,7 +58,10 @@ closure_js_library(
     name = "t",
     testonly = True,
     srcs = ["t.js"],
-    suppress = ["lintChecks"],  # use of goog.provide
+    suppress = [
+        "lintChecks",
+        "superfluousSuppress",
+    ],  # use of goog.provide
 )
 
 file_test(
@@ -99,7 +111,10 @@ file_test(
 closure_js_library(
     name = "b2",
     srcs = ["b.js"],
-    suppress = ["lintChecks"],  # use of goog.provide
+    suppress = [
+        "lintChecks",
+        "superfluousSuppress",
+    ],  # use of goog.provide
     exports = [":a"],
     deps = [":a"],
 )
@@ -107,7 +122,10 @@ closure_js_library(
 closure_js_library(
     name = "exportMadeTransitiveDepDirect",
     srcs = ["c.js"],
-    suppress = ["lintChecks"],  # use of goog.provide
+    suppress = [
+        "lintChecks",
+        "superfluousSuppress",
+    ],  # use of goog.provide
     deps = [":b2"],  # but if :b exports :a, then we're ok
 )
 
@@ -217,7 +235,10 @@ closure_js_library(
         "a.js",
         "es6_a.js",
     ],
-    suppress = ["lintChecks"],  # use of goog.provide
+    suppress = [
+        "lintChecks",
+        "superfluousSuppress",
+    ],  # use of goog.provide
 )
 
 file_test(

--- a/closure/protobuf/test/legacy/BUILD
+++ b/closure/protobuf/test/legacy/BUILD
@@ -28,7 +28,10 @@ closure_js_proto_library(
 closure_js_library(
     name = "example_lib",
     srcs = ["example.js"],
-    suppress = ["lintChecks"],  # use of goog.provide
+    suppress = [
+        "lintChecks",
+        "superfluousSuppress",
+    ],  # use of goog.provide
     deps = [
         ":example_proto",
     ],

--- a/closure/protobuf/test/legacy/BUILD
+++ b/closure/protobuf/test/legacy/BUILD
@@ -28,6 +28,7 @@ closure_js_proto_library(
 closure_js_library(
     name = "example_lib",
     srcs = ["example.js"],
+    suppress = ["lintChecks"],  # use of goog.provide
     deps = [
         ":example_proto",
     ],

--- a/closure/templates/test/BUILD
+++ b/closure/templates/test/BUILD
@@ -107,7 +107,10 @@ closure_js_template_library(
 closure_js_library(
     name = "greeter_lib",
     srcs = ["greeter.js"],
-    suppress = ["lintChecks"],  # use of goog.provide
+    suppress = [
+        "lintChecks",
+        "superfluousSuppress",
+    ],  # use of goog.provide
     deps = [
         ":greeter_soy",
         "//closure/library/soy",
@@ -117,7 +120,10 @@ closure_js_library(
 closure_js_library(
     name = "greeter_proto_lib",
     srcs = ["greeter_proto.js"],
-    suppress = ["lintChecks"],  # use of goog.provide
+    suppress = [
+        "lintChecks",
+        "superfluousSuppress",
+    ],  # use of goog.provide
     deps = [
         ":greeter_proto_soy",
         ":person_proto",

--- a/closure/templates/test/BUILD
+++ b/closure/templates/test/BUILD
@@ -107,6 +107,7 @@ closure_js_template_library(
 closure_js_library(
     name = "greeter_lib",
     srcs = ["greeter.js"],
+    suppress = ["lintChecks"],  # use of goog.provide
     deps = [
         ":greeter_soy",
         "//closure/library/soy",
@@ -116,6 +117,7 @@ closure_js_library(
 closure_js_library(
     name = "greeter_proto_lib",
     srcs = ["greeter_proto.js"],
+    suppress = ["lintChecks"],  # use of goog.provide
     deps = [
         ":greeter_proto_soy",
         ":person_proto",

--- a/closure/testing/test/BUILD
+++ b/closure/testing/test/BUILD
@@ -21,7 +21,10 @@ load("//closure:defs.bzl", "closure_js_library", "closure_js_test")
 closure_js_library(
     name = "arithmetic_lib",
     srcs = ["arithmetic.js"],
-    suppress = ["lintChecks"],  # use of goog.provide
+    suppress = [
+        "lintChecks",
+        "superfluousSuppress",
+    ],  # use of goog.provide
 )
 
 closure_js_test(

--- a/closure/testing/test/BUILD
+++ b/closure/testing/test/BUILD
@@ -21,6 +21,7 @@ load("//closure:defs.bzl", "closure_js_library", "closure_js_test")
 closure_js_library(
     name = "arithmetic_lib",
     srcs = ["arithmetic.js"],
+    suppress = ["lintChecks"],  # use of goog.provide
 )
 
 closure_js_test(


### PR DESCRIPTION
Closure compiler will soon emit a linter warning on `goog.provide`, as
[`goog.module`](https://github.com/google/closure-library/wiki/goog.module:-an-ES6-module-like-alternative-to-goog.provide#googmodule) is preferred for new code.