### PR TITLE
Remove deprecated closure_repositories() macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,6 @@ rules_closure_toolchains()
 You are not required to install the Closure Tools, PhantomJS, or anything else
 for that matter; they will be fetched automatically by Bazel.
 
-> :bangbang: Release 0.10.x will be the last to support loading dependencies though
-> `closure_repositories()`.
-
 ### Overriding Dependency Versions
 
 When you call `rules_closure_dependencies()` in your `WORKSPACE` file, it causes a

--- a/closure/defs.bzl
+++ b/closure/defs.bzl
@@ -28,7 +28,6 @@ load("//closure/templates:closure_templates_plugin.bzl", _closure_templates_plug
 load("//closure/testing:closure_js_test.bzl", _closure_js_test = "closure_js_test")
 load("//closure/testing:phantomjs_test.bzl", _phantomjs_test = "phantomjs_test")
 load("//closure:filegroup_external.bzl", _filegroup_external = "filegroup_external")
-load("//closure:repositories.bzl", _closure_repositories = "closure_repositories")
 load("//closure:webfiles/web_library.bzl", _web_library = "web_library")
 load("//closure:webfiles/web_library_external.bzl", _web_library_external = "web_library_external")
 
@@ -49,6 +48,5 @@ closure_templates_plugin = _closure_templates_plugin
 closure_js_test = _closure_js_test
 phantomjs_test = _phantomjs_test
 filegroup_external = _filegroup_external
-closure_repositories = _closure_repositories  # TODO(yannic): Remove on 2019-11-01.
 web_library = _web_library
 web_library_external = _web_library_external

--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -18,22 +18,6 @@ load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file")
 load("//closure/private:platform_http_file.bzl", "platform_http_file")
 
-_ERROR_CLOSURE_REPOSITORIES_IS_DEPRECATED = """
-closure_repositories() is deprecated.
-
-Please add the following to your workspace instead:
-
-  load("@io_bazel_rules_closure//closure:repositories.bzl", "rules_closure_dependencies", "rules_closure_toolchains")
-  rules_closure_dependencies()
-  rules_closure_toolchains()
-""".strip()
-
-def closure_repositories(**kargs):
-    """Legacy macro to import dependencies for Closure Rules."""
-
-    print(_ERROR_CLOSURE_REPOSITORIES_IS_DEPRECATED)
-    rules_closure_dependencies(**kargs)
-
 def rules_closure_toolchains():
     """An utility method to load all Closure toolchains.
 
@@ -70,7 +54,6 @@ def rules_closure_dependencies(
         omit_com_google_javascript_closure_library = False,
         omit_com_google_jsinterop_annotations = False,
         omit_com_google_protobuf = False,
-        omit_com_google_protobuf_java = False,
         omit_com_google_protobuf_js = False,
         omit_com_google_template_soy = False,
         omit_com_google_template_soy_jssrc = False,
@@ -98,8 +81,6 @@ def rules_closure_dependencies(
         omit_rules_python = False,
         omit_zlib = False):
     """Imports dependencies for Closure Rules."""
-    if omit_com_google_protobuf_java:
-        fail("omit_com_google_protobuf_java no longer supported and must be not be passed to closure_repositories()")
     if not omit_aopalliance:
         aopalliance()
     if not omit_args4j:


### PR DESCRIPTION
This was deprecated in favor of `rules_closure_dependencies()` and
`rules_closure_toolchains()` to be more consistent with other rules.
See https://docs.bazel.build/versions/master/skylark/deploying.html#dependencies

Updates #421