### PR TITLE
Restore protobuf patch to drop java 7 compatibility

### DIFF
--- a/closure/BUILD
+++ b/closure/BUILD
@@ -16,6 +16,8 @@ licenses(["notice"])  # Apache 2.0
 
 load("//closure/private:lines_sorted_test.bzl", "lines_sorted_test")
 
+exports_files(["protobuf_drop_java_7_compatibility.patch"])
+
 lines_sorted_test(
     name = "repositories_defs_sorted_test",
     cmd = "sed '1,/BEGIN_DECLARATIONS/ d' $< | grep ^def >$@",

--- a/closure/protobuf_drop_java_7_compatibility.patch
+++ b/closure/protobuf_drop_java_7_compatibility.patch
@@ -1,0 +1,39 @@
+diff --git a/BUILD b/BUILD.bazel
+index efc3d8e..2f27833 100644
+--- a/BUILD
++++ b/BUILD.bazel
+@@ -653,10 +653,7 @@ java_library(
+     ],
+     javacopts = select({
+         "//:jdk9": ["--add-modules=jdk.unsupported"],
+-        "//conditions:default": [
+-            "-source 7",
+-            "-target 7",
+-        ],
++        "//conditions:default": [],
+     }),
+     visibility = ["//visibility:public"],
+ )
+@@ -754,10 +751,7 @@ java_library(
+     ],
+     javacopts = select({
+         "//:jdk9": ["--add-modules=jdk.unsupported"],
+-        "//conditions:default": [
+-            "-source 7",
+-            "-target 7",
+-        ],
++        "//conditions:default": [],
+     }),
+     visibility = ["//visibility:public"],
+ )
+@@ -767,10 +761,6 @@ java_library(
+     srcs = glob([
+         "java/util/src/main/java/com/google/protobuf/util/*.java",
+     ]),
+-    javacopts = [
+-        "-source 7",
+-        "-target 7",
+-    ],
+     visibility = ["//visibility:public"],
+     deps = [
+         "protobuf_java",

--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -741,6 +741,10 @@ def com_google_jsinterop_annotations():
 def com_google_protobuf():
     http_archive(
         name = "com_google_protobuf",
+        patches = [
+            "@io_bazel_rules_closure//closure:protobuf_drop_java_7_compatibility.patch",
+        ],
+        patch_args = ["-p1"],
         strip_prefix = "protobuf-3.11.4",
         sha256 = "a79d19dcdf9139fa4b81206e318e33d245c4c9da1ffed21c87288ed4380426f9",
         urls = [

--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -739,6 +739,8 @@ def com_google_jsinterop_annotations():
     )
 
 def com_google_protobuf():
+    # TODO(davido): Remove the patching procedure when this PR is merged:
+    # https://github.com/protocolbuffers/protobuf/pull/7306
     http_archive(
         name = "com_google_protobuf",
         patches = [


### PR DESCRIPTION
This partially reverts canges done in: https://github.com/bazelbuild/rules_closure/commit/3bdfdbf9dcad4f6b0335072219ac04fa6e059636.

As the consequence building downstream e.g. Gerrit Code Review re-introduced these annoying warnings:

```
INFO: From Building external/io_bazel_rules_closure/java/io/bazel/rules/closure/worker/libworker_protocol_proto-speed.jar (1 source jar) [for host]:
warning: -parameters is not supported for target value 1.7. Use 1.8 or later.
INFO: From Building external/io_bazel_rules_closure/java/io/bazel/rules/closure/webfiles/libbuild_info_proto-speed.jar (1 source jar) [for host]:
warning: -parameters is not supported for target value 1.7. Use 1.8 or later.
INFO: From Building external/io_bazel_rules_closure/java/io/bazel/rules/closure/libbuild_info_proto-speed.jar (1 source jar) [for host]:
warning: -parameters is not supported for target value 1.7. Use 1.8 or later.
Comment 1 by david.pursehouse@gmail.com on Tue, Jul 2, 2019, 3:03 AM GMT+2 
```

Related Gerrit Issue: [1]. Related Bazel Issue: [2]. Rejected attempt to drop Java 7 compatibility in Protobuf: [3].

[1] https://bugs.chromium.org/p/gerrit/issues/detail?id=11102
[2] https://github.com/bazelbuild/bazel/issues/8772
[3] https://github.com/protocolbuffers/protobuf/pull/6711