### PR TITLE
Remove ref to "transitionalforwarddeclarations.js"

### DIFF
--- a/closure/private/BUILD
+++ b/closure/private/BUILD
@@ -29,6 +29,5 @@ closure_base_js_library(
     name = "base_lib",
     srcs = [
         "@com_google_javascript_closure_library//:closure/goog/base.js",
-        "@com_google_javascript_closure_library//:closure/goog/transitionalforwarddeclarations.js",
     ],
 )


### PR DESCRIPTION
This should never have been included in the public repository as it was only intended for legacy projects.