### PR TITLE
Fix incorrect usage of truth function `containsExactly`

### DIFF
--- a/javatests/io/bazel/rules/closure/worker/testing/ProgramResult.java
+++ b/javatests/io/bazel/rules/closure/worker/testing/ProgramResult.java
@@ -100,7 +100,7 @@ public abstract class ProgramResult {
       checkArgument(warnings.length > 0);
       check("warnings()")
           .that(actual.warnings())
-          .containsExactly(Arrays.asList(warnings))
+          .containsExactlyElementsIn(warnings)
           .inOrder();
       return this;
     }
@@ -115,7 +115,7 @@ public abstract class ProgramResult {
       checkArgument(warnings.length > 0);
       check("warnings()")
           .that(actual.warnings())
-          .containsExactly(Arrays.asList(warnings))
+          .containsExactlyElementsIn(warnings)
           .inOrder();
     }
   }


### PR DESCRIPTION
The truth function `containsExactly` expects an Object... (array) and internally converts that to a List. By already passing-in a list, it will convert that list object into another list. 
Using `containsExactlyElementsIn` instead.