### PR TITLE
Remove last remaining reference to removed Closure Compiler diagnostic group.

### DIFF
--- a/java/com/google/javascript/jscomp/Diagnostics.java
+++ b/java/com/google/javascript/jscomp/Diagnostics.java
@@ -57,7 +57,6 @@ final class Diagnostics {
           "nonStandardJsDocs",
           "setTestOnly",
           "strictDependencies",
-          "strictMissingRequire",
           "strictModuleChecks",
           "superfluousSuppress",
           "underscore");


### PR DESCRIPTION
The CheckMissingAndExtraRequires pass that this diagnostic referred to has been removed in favor of the
CheckMissingRequires pass, which can now be turned on via the more simply named "missingRequire" diagnostic group.