### PR TITLE
Make compiler report tests less fragile

### DIFF
--- a/closure/compiler/test/reports/BUILD
+++ b/closure/compiler/test/reports/BUILD
@@ -35,12 +35,12 @@ closure_js_binary(
 
 file_test(
     name = "propertyWithoutQuotes_getsRenamed",
-    content = "console.log({a:\"world\"});\n",
+    regexp = r'console.log({\w:"world"});',
     file = "property_bin.js",
 )
 
 file_test(
     name = "propertyRenamingReportDef_createsAdditionalOutputFile",
-    content = "hello:a\n",
+    regexp = "hello:\\w",
     file = "property_bin_renaming_report.txt",
 )


### PR DESCRIPTION
Current tests are asserting particular obfuscated names which is fragile.

Patch converts the test to use regex instead.