### PR TITLE
Include srcs in inputs to compiler action.

### DIFF
--- a/closure/compiler/closure_js_binary.bzl
+++ b/closure/compiler/closure_js_binary.bzl
@@ -249,6 +249,7 @@ def _impl(ctx):
         map_each = _get_src_path,
         expand_directories = True,
     )
+    inputs.extend(js.srcs.to_list())
 
     # As a matter of policy, we don't add attributes to this rule just because we
     # can. We only add attributes when the Skylark code adds value beyond merely


### PR DESCRIPTION
This was accidentally left out of https://github.com/bazelbuild/rules_closure/pull/517.

We should probably use a depset to avoid calling to_list, but that's a larger refactor than I'm willing to do right now.