### PR TITLE
Add user flags before srcs file on compiler command line.

### DIFF
--- a/closure/compiler/closure_js_binary.bzl
+++ b/closure/compiler/closure_js_binary.bzl
@@ -242,15 +242,7 @@ def _impl(ctx):
 
     all_args = ctx.actions.args()
     all_args.add_all(args)
-
-    # We shall now pass all transitive sources, including externs files.
-    all_args.add_all(
-        js.srcs,
-        map_each = _get_src_path,
-        expand_directories = True,
-    )
-    inputs.extend(js.srcs.to_list())
-
+    
     # As a matter of policy, we don't add attributes to this rule just because we
     # can. We only add attributes when the Skylark code adds value beyond merely
     # passing those flags along to the Closure Compiler. So users wishing to use
@@ -259,6 +251,14 @@ def _impl(ctx):
     # could pass `defs = ["--env=CUSTOM"]` to get rid of browser externs and
     # slightly speed up compilation.
     all_args.add_all(ctx.attr.defs)
+
+    # We shall now pass all transitive sources, including externs files.
+    all_args.add_all(
+        js.srcs,
+        map_each = _get_src_path,
+        expand_directories = True,
+    )
+    inputs.extend(js.srcs.to_list())
 
     # Insert an edge into the build graph that produces the minified version of
     # all JavaScript sources in the transitive closure, sans dead code.

--- a/closure/compiler/test/BUILD
+++ b/closure/compiler/test/BUILD
@@ -237,12 +237,11 @@ sh_test(
 closure_js_binary(
     name = "bin_with_defs",
     deps = ["hello_lib"],
-    defs = ["--print_ast"],
-
+    defs = ["--checks_only"],
 )
 
 file_test(
     name = "defs_test",
-    regexp = "digraph AST {",
+    content = "",
     file = "bin_with_defs.js",
 )

--- a/closure/compiler/test/BUILD
+++ b/closure/compiler/test/BUILD
@@ -232,3 +232,17 @@ sh_test(
         ":exports_data",
     ],
 )
+
+# Test defs argument of closure_binary works fine
+closure_js_binary(
+    name = "bin_with_defs",
+    deps = ["hello_lib"],
+    defs = ["--print_ast"],
+
+)
+
+file_test(
+    name = "defs_test",
+    regexp = "digraph AST {",
+    file = "bin_with_defs.js",
+)


### PR DESCRIPTION
User can use the rule argument `defs` in order to pass specific flags to the closure compiler. Those flags need to be passed on the command line before the list of srcs file otherwise they are considered a srcs file name and compilation fails.