### PR TITLE
Remove obsolete proto compiler option

### DIFF
--- a/closure/protobuf/closure_js_proto_library.bzl
+++ b/closure/protobuf/closure_js_proto_library.bzl
@@ -38,7 +38,7 @@ def closure_js_proto_library(
         protocbin = Label("@com_google_protobuf//:protoc"),
         **kwargs):
     cmd = ["$(location %s)" % protocbin]
-    js_out_options = ["library=%s,error_on_name_conflict" % name]
+    js_out_options = ["library=%s" % name]
     if add_require_for_enums:
         js_out_options += ["add_require_for_enums"]
     if testonly:


### PR DESCRIPTION
When the `error_on_name_conflict` option was introduced, the compiler produced one output file per message name, regardless of the message's namespace. So `foo.Message1` and `bar.Message1` would both yield a file named `message1.js`, and the compiler would overwrite this file and only keep the last generated file. The `error_on_name_conflict` option was added to allow a compile time check for duplicate file names instead of the compiler silently overwriting files.

This "last output file wins" behavior was removed in [https://github.com/protocolbuffers/protobuf/commit/0894e07536af88065d462cdc9d8e807c0723ef4d](https://github.com/protocolbuffers/protobuf/commit/0894e07536af88065d462cdc9d8e807c0723ef4d) (see js_generator.cc). Now, instead of overwriting existing files, the compiler will prefix otherwise duplicate filenames with the message namespace, ensuring unique file names.

Since this option is now a no-op, it should be removed.