### PR TITLE
Deprecate closure_js_deps.

### DIFF
--- a/closure/compiler/closure_js_deps.bzl
+++ b/closure/compiler/closure_js_deps.bzl
@@ -23,6 +23,10 @@ load(
     "unfurl",
 )
 
+_ERROR_CLOSURE_JS_DEPS_IS_DEPRECATED = """
+closure_js_deps() and deps.js files are deprecated. Please remove your closure_js_deps rules and, if needed, use the google-closure-deps npm module with bazelbuild/rules_nodejs to generate deps.js files.
+""".strip()
+
 def _impl(ctx):
     deps = unfurl(ctx.attr.deps, provider = "closure_js_library")
     js = collect_js(deps)
@@ -30,6 +34,8 @@ def _impl(ctx):
     closure_root = _dirname(long_path(ctx, base_srcs[0]))
     closure_rel = "/".join([".." for _ in range(len(closure_root.split("/")))])
     outputs = [ctx.outputs.out]
+
+    print(_ERROR_CLOSURE_JS_DEPS_IS_DEPRECATED)
 
     # XXX: Other files in same directory will get schlepped in w/o sandboxing.
     ctx.actions.run(


### PR DESCRIPTION
Per #526, we should eventually delete the `closure_js_deps` rule, because
* it depends on a deprecated (and soon to be deleted) Closure Library script
* it generates `deps.js` files, which themselves are deprecated
* it sees very little usage (and in many of its usages, it's not necessary)

This PR deprecates it first.