### PR TITLE
Remove reference to analyzerChecksInternal

### DIFF
--- a/closure/compiler/closure_js_library.bzl
+++ b/closure/compiler/closure_js_library.bzl
@@ -126,7 +126,6 @@ def _closure_js_library_impl(
     if lenient:
         suppress = suppress + [
             "analyzerChecks",
-            "analyzerChecksInternal",
             "deprecated",
             "legacyGoogScopeRequire",
             "lintChecks",


### PR DESCRIPTION
This is a no-op. in older versions of Closure compiler this diagnostic
group is a strict subset of analyzerChecks. As of https://github.com/google/closure-compiler/commit/09e5fdf5af2a86f9ca92462b61c062224766646e,
the diagnostic is deprecated/slated for deletion and an alias of analyzerChecks.