### PR TITLE
Set default language_in to "STABLE"

### DIFF
--- a/closure/private/defs.bzl
+++ b/closure/private/defs.bzl
@@ -22,7 +22,7 @@ JS_LANGUAGE_DEFAULT = "ECMASCRIPT5_STRICT"
 JS_TEST_FILE_TYPE = ["_test.js"]
 SOY_FILE_TYPE = [".soy"]
 
-JS_LANGUAGE_IN = "ECMASCRIPT_2017"
+JS_LANGUAGE_IN = "STABLE"
 JS_LANGUAGE_OUT_DEFAULT = "ECMASCRIPT5"
 JS_LANGUAGES = depset([
     "ECMASCRIPT3",
@@ -276,7 +276,7 @@ def library_level_checks(
         "--jscomp_off",
         "reportUnknownTypes",
         "--language_in",
-        "ECMASCRIPT_2017",
+        "STABLE",
         "--language_out",
         "ECMASCRIPT5",
         "--js_output_file",

--- a/java/com/google/javascript/jscomp/JsChecker.java
+++ b/java/com/google/javascript/jscomp/JsChecker.java
@@ -171,7 +171,7 @@ public final class JsChecker {
     // configure compiler
     Compiler compiler = new Compiler();
     CompilerOptions options = new CompilerOptions();
-    options.setLanguage(LanguageMode.ECMASCRIPT_2017);
+    options.setLanguage(LanguageMode.STABLE);
     options.setStrictModeInput(true);
     options.setIncrementalChecks(IncrementalCheckMode.GENERATE_IJS);
     options.setCodingConvention(convention.convention);


### PR DESCRIPTION
This is a better alternative compared to pinning a specific version.  The compiler's documentation recommends against pinning, which causes surprising breakages when upstream code introduces newer language features.  This has passed an internal global presubmit.