### PR TITLE
Explicitly set the `--emit_use_strict` flag

### DIFF
--- a/closure/compiler/test/BUILD
+++ b/closure/compiler/test/BUILD
@@ -70,7 +70,8 @@ file_test(
 
 closure_js_binary(
     name = "hello_es5strict_bin",
-    language = "ECMASCRIPT5_STRICT",
+    defs = ["--emit_use_strict=true"],
+    language = "ECMASCRIPT5",
     deps = [":hello_lib"],
 )
 


### PR DESCRIPTION
This makes this test case compatible with an upcoming compiler change that makes `--emit_use_strict` false by default.