### PR TITLE
Explicitly add --emit_use_strict

### DIFF
--- a/closure/compiler/test/BUILD
+++ b/closure/compiler/test/BUILD
@@ -38,8 +38,8 @@ file_test(
 
 file_test(
     name = "sourcemap_doesntContainWeirdBazelDirectories",
-    regexp = r'"sources":\["/closure/compiler/test/hello.js"\]',
     file = "hello_bin.js.map",
+    regexp = r'"sources":\["/closure/compiler/test/hello.js"\]',
 )
 
 # Make sure bazel doesn't complain about some outputs not created.
@@ -64,12 +64,13 @@ file_test(
 
 file_test(
     name = "sourcemapWithWrapper_hasDifferentMappingCodes",
-    regexp = r'"mappings":"[A-Za-z,]\+;",',
     file = "hello_wrap_bin.js.map",
+    regexp = r'"mappings":"[A-Za-z,]\+;",',
 )
 
 closure_js_binary(
     name = "hello_es5strict_bin",
+    defs = ["--emit_use_strict=true"],
     language = "ECMASCRIPT5_STRICT",
     deps = [":hello_lib"],
 )


### PR DESCRIPTION
This is a no-op with older Closure Compiler releases because of a command line runner bug, where `--emit_use_strict=true` is ignored. That's why https://github.com/bazelbuild/rules_closure/pull/540
had test failures. (Also, @blickly  is on leave so can't update that PR)

This PR fixes the Google-internal CI which runs the compiler at head.
Keeping `language = ECMASCRIPT5_STRICT` avoids the CI failures from https://github.com/bazelbuild/rules_closure/pull/540, but is unnecessary with the latest Closure Compiler version.

Landing https://github.com/bazelbuild/rules_closure/pull/541 would make
this PR unnecessary. But I'd like to submit this earlier if possible to fix the Google CI.