### PR TITLE
removing dots from soy template name

### DIFF
--- a/java/io/bazel/rules/closure/webfiles/server/listing.soy
+++ b/java/io/bazel/rules/closure/webfiles/server/listing.soy
@@ -18,7 +18,7 @@
 /**
  * Displays page listing paths in transitive closure.
  */
-{template .listing}
+{template listing}
   {@param label: string}
   {@param paths: list<string>}
   <!doctype html>


### PR DESCRIPTION
This was requested by the soy team as dots are being cleaned up in the depot.