### PR TITLE
Update Setup instructions to use 0.12.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "io_bazel_rules_closure",
-    sha256 = "7d206c2383811f378a5ef03f4aacbcf5f47fd8650f6abbc3fa89f3a27dd8b176",
-    strip_prefix = "rules_closure-0.10.0",
+    sha256 = "9498e57368efb82b985db1ed426a767cbf1ba0398fd7aed632fc3908654e1b1e",
+    strip_prefix = "rules_closure-0.12.0",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/0.10.0.tar.gz",
-        "https://github.com/bazelbuild/rules_closure/archive/0.10.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_closure/archive/0.12.0.tar.gz",
+        "https://github.com/bazelbuild/rules_closure/archive/0.12.0.tar.gz",
     ],
 )
 


### PR DESCRIPTION
Closes https://github.com/bazelbuild/rules_closure/issues/552

Since we are not modifying any code, we can [skip ci].
