### PR TITLE
Remove Travis CI badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Closure Rules for Bazel (αlpha) ![Travis build status](https://travis-ci.org/bazelbuild/rules_closure.svg?branch=master) [![Bazel CI build status](https://badge.buildkite.com/7569410e2a2661076591897283051b6d137f35102167253fed.svg)](https://buildkite.com/bazel/closure-compiler-rules-closure-postsubmit)
+# Closure Rules for Bazel (αlpha) [![Bazel CI build status](https://badge.buildkite.com/7569410e2a2661076591897283051b6d137f35102167253fed.svg)](https://buildkite.com/bazel/closure-compiler-rules-closure-postsubmit)
 
 JavaScript | Templating | Stylesheets | Miscellaneous
 --- | --- | --- | ---


### PR DESCRIPTION
The `.travis.yml` config was [removed in 2019][1] with the message:

> ### Delete .travis.yml (#422)
>  
> We now test exclusively on BuildKite which is maintained by Bazel team

Since we are not modifying any code, we can [skip ci].

[1]: https://github.com/bazelbuild/rules_closure/commit/7b43c90d9c63c621dae7d34b07198a9f37219ca9