### PR TITLE
Add attribute to web_library for host:port

### DIFF
--- a/closure/webfiles/test/BUILD
+++ b/closure/webfiles/test/BUILD
@@ -24,7 +24,7 @@ web_library(
     srcs = ["index.html"],
     path = "/",
     deps = [":stuff"],
-    bind = "0.0.0.0:8080"
+    port = "8080"
 )
 
 web_library(

--- a/closure/webfiles/test/BUILD
+++ b/closure/webfiles/test/BUILD
@@ -24,6 +24,7 @@ web_library(
     srcs = ["index.html"],
     path = "/",
     deps = [":stuff"],
+    bind = "0.0.0.0:8080"
 )
 
 web_library(

--- a/closure/webfiles/web_library.bzl
+++ b/closure/webfiles/web_library.bzl
@@ -128,7 +128,7 @@ def _web_library(ctx):
     # define development web server that only applies to this transitive closure
     params = struct(
         label = str(ctx.label),
-        bind = "[::]:6006",
+        bind = str(ctx.attr.bind),
         manifest = [long_path(ctx, man) for man in manifests.to_list()],
         external_asset = [
             struct(webpath = k, path = v)
@@ -209,6 +209,7 @@ web_library = rule(
     executable = True,
     attrs = {
         "path": attr.string(),
+        "bind": attr.string(default = "0.0.0.0:6006"),
         "srcs": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = ["webfiles"]),
         "exports": attr.label_list(),

--- a/closure/webfiles/web_library.bzl
+++ b/closure/webfiles/web_library.bzl
@@ -128,7 +128,7 @@ def _web_library(ctx):
     # define development web server that only applies to this transitive closure
     params = struct(
         label = str(ctx.label),
-        bind = str(ctx.attr.bind),
+        bind = "%s:%s" % (str(ctx.attr.host), str(ctx.attr.port)),
         manifest = [long_path(ctx, man) for man in manifests.to_list()],
         external_asset = [
             struct(webpath = k, path = v)
@@ -209,7 +209,8 @@ web_library = rule(
     executable = True,
     attrs = {
         "path": attr.string(),
-        "bind": attr.string(default = "0.0.0.0:6006"),
+        "host": attr.string(default = "0.0.0.0"),
+        "port": attr.string(default = "6006"),
         "srcs": attr.label_list(allow_files = True),
         "deps": attr.label_list(providers = ["webfiles"]),
         "exports": attr.label_list(),


### PR DESCRIPTION
Example (from test):

```
web_library(
    name = "raven",
    srcs = ["index.html"],
    path = "/",
    deps = [":stuff"],
    host = "0.0.0.0",
    port = "8080"
)
```

(Supersedes #557.)