### PR TITLE
Support testing with webdriver and rules_webtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ http_archive(
 load("@io_bazel_rules_closure//closure:repositories.bzl", "rules_closure_dependencies", "rules_closure_toolchains")
 rules_closure_dependencies()
 rules_closure_toolchains()
+
+# Only needed if you want to run your tests on headless Chrome
+load("@io_bazel_rules_closure//closure:defs.bzl", "setup_web_test_repositories")
+setup_web_test_repositories(
+    chromium = True,
+)
 ```
 
 You are not required to install the Closure Tools, PhantomJS, or anything else

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -131,3 +131,8 @@ java_import_external(
     testonly_ = 1,
     deps = ["@com_google_guava"],
 )
+
+load("//closure:defs.bzl", "setup_web_test_repositories")
+setup_web_test_repositories(
+    chromium = True,
+)

--- a/closure/defs.bzl
+++ b/closure/defs.bzl
@@ -26,6 +26,7 @@ load("//closure/templates:closure_js_template_library.bzl", _closure_js_template
 load("//closure/templates:closure_templates_plugin.bzl", _closure_templates_plugin = "closure_templates_plugin")
 load("//closure/testing:closure_js_test.bzl", _closure_js_test = "closure_js_test")
 load("//closure/testing:phantomjs_test.bzl", _phantomjs_test = "phantomjs_test")
+load("//closure/testing:web_test_repositories.bzl", _setup_web_test_repositories = "setup_web_test_repositories")
 load("//closure:filegroup_external.bzl", _filegroup_external = "filegroup_external")
 load("//closure:webfiles/web_library.bzl", _web_library = "web_library")
 load("//closure:webfiles/web_library_external.bzl", _web_library_external = "web_library_external")
@@ -45,6 +46,7 @@ closure_js_template_library = _closure_js_template_library
 closure_templates_plugin = _closure_templates_plugin
 closure_js_test = _closure_js_test
 phantomjs_test = _phantomjs_test
+setup_web_test_repositories = _setup_web_test_repositories
 filegroup_external = _filegroup_external
 web_library = _web_library
 web_library_external = _web_library_external

--- a/closure/repositories.bzl
+++ b/closure/repositories.bzl
@@ -79,6 +79,7 @@ def rules_closure_dependencies(
         omit_rules_jvm_external = False,
         omit_rules_proto = False,
         omit_rules_python = False,
+        omit_rules_webtesting = False,
         omit_zlib = False):
     """Imports dependencies for Closure Rules."""
     if not omit_aopalliance:
@@ -189,6 +190,8 @@ def rules_closure_dependencies(
         rules_proto()
     if not omit_rules_python:
         rules_python()
+    if not omit_rules_webtesting:
+        rules_webtesting()
     if not omit_zlib:
         zlib()
 
@@ -1071,6 +1074,33 @@ def rules_python():
             "https://mirror.bazel.build/github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz",
             "https://github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz",
         ],
+    )
+
+def rules_webtesting():
+    # TODO: Please remove the two following dependencies when rules_webtesting is pinned to an official release (>0.3.5).
+    http_archive(
+        name = "io_bazel_rules_go",
+        sha256 = "099a9fb96a376ccbbb7d291ed4ecbdfd42f6bc822ab77ae6f1b5cb9e914e94fa",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip",
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.35.0/rules_go-v0.35.0.zip",
+        ],
+    )
+
+    http_archive(
+        name = "bazel_gazelle",
+        sha256 = "62ca106be173579c0a167deb23358fdfe71ffa1e4cfdddf5582af26520f1c66f",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.23.0/bazel-gazelle-v0.23.0.tar.gz",
+        ],
+    )
+
+    http_archive(
+        name = "io_bazel_rules_webtesting",
+        sha256 = "72355642d053b5df75f33d6e950d089c313677cebb97b373ad125ed2e4f32119",
+        strip_prefix = "rules_webtesting-d8c4843cdb44cadae1fb43a1f64e17492697de7f",
+        urls = ["https://github.com/bazelbuild/rules_webtesting/archive/d8c4843cdb44cadae1fb43a1f64e17492697de7f.tar.gz"],
     )
 
 def zlib():

--- a/closure/testing/BUILD
+++ b/closure/testing/BUILD
@@ -22,6 +22,11 @@ licenses(["notice"])  # Apache 2.0
 load("//closure:defs.bzl", "closure_js_binary", "closure_js_library")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
+# TODO: Consider sharing this with phantomjs.
+# html template used by webdriver_test.
+exports_files(["gen_webtest_html.template"])
+
+# html place holder used by phantomjs_test.
 exports_files(["empty.html"])
 
 closure_js_library(

--- a/closure/testing/closure_js_test.bzl
+++ b/closure/testing/closure_js_test.bzl
@@ -17,6 +17,7 @@
 load("//closure/compiler:closure_js_binary.bzl", "closure_js_binary")
 load("//closure/compiler:closure_js_library.bzl", "closure_js_library")
 load("//closure/testing:phantomjs_test.bzl", "phantomjs_test")
+load("//closure/testing:webdriver_test.bzl", "webdriver_test")
 
 def closure_js_test(
         name,
@@ -34,6 +35,7 @@ def closure_js_test(
         visibility = None,
         tags = [],
         debug = False,
+        browsers = None,
         **kwargs):
     if not srcs:
         fail("closure_js_test rules can not have an empty 'srcs' list")
@@ -78,16 +80,26 @@ def closure_js_test(
             tags = tags,
         )
 
-        phantomjs_test(
-            name = shard,
-            runner = str(Label("//closure/testing:phantomjs_jsunit_runner")),
-            deps = [":%s_bin" % shard],
-            debug = debug,
-            html = html,
-            visibility = visibility,
-            tags = tags,
-            **kwargs
-        )
+        if not browsers:
+            phantomjs_test(
+                name = shard,
+                runner = Label("//closure/testing:phantomjs_jsunit_runner"),
+                deps = [":%s_bin" % shard],
+                debug = debug,
+                html = html,
+                visibility = visibility,
+                tags = tags,
+                **kwargs
+            )
+
+        else:
+            webdriver_test(
+                name = shard,
+                test_file_js = "%s_bin.js" % shard,
+                browsers = browsers,
+                visibility = visibility,
+                tags = tags,
+            )
 
     if len(srcs) > 1:
         native.test_suite(
@@ -98,3 +110,4 @@ def closure_js_test(
 
 def _make_suffix(path):
     return "_" + path.replace("_test.js", "").replace("-", "_").replace("/", "_")
+

--- a/closure/testing/gen_webtest_html.template
+++ b/closure/testing/gen_webtest_html.template
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+<head>
+<!--
+Copyright 2022 The Closure Rules Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+</head>
+<body>
+<!--
+This is a template of the default test file used for running JS tests
+declared with closure_js_test rules.
+-->
+<script>
+  // goog.require does not need to fetch sources from the local
+  // server because everything is compiled and loaded explicitly below.
+  var CLOSURE_NO_DEPS = true;
+  var CLOSURE_UNCOMPILED_DEFINES = {};
+</script>
+<script src="{{TEST_FILE_JS}}"></script>
+</body>
+</html>
+

--- a/closure/testing/test/BUILD
+++ b/closure/testing/test/BUILD
@@ -125,6 +125,49 @@ closure_js_test(
     ],
 )
 
+# Webtest examples
+closure_js_test(
+    name = "simple_webtest_test",
+    timeout = "short",
+    srcs = ["simple_test.js"],
+    deps = [
+        "@com_google_javascript_closure_library//closure/goog/testing:asserts",
+        "@com_google_javascript_closure_library//closure/goog/testing:jsunit",
+    ],
+    browsers = ["@io_bazel_rules_webtesting//browsers:chromium-local"],
+    tags = ["local", "manual"],
+)
+
+closure_js_test(
+    name = "arithmetic_module_webtest_test",
+    timeout = "short",
+    srcs = ["arithmetic_module_test.js"],
+    entry_points = ["goog:arithmetic_module_test"],
+    deps = [
+        ":arithmetic_module_lib",
+        "@com_google_javascript_closure_library//closure/goog/testing:asserts",
+        "@com_google_javascript_closure_library//closure/goog/testing:jsunit",
+        "@com_google_javascript_closure_library//closure/goog/testing:testsuite",
+    ],
+    browsers = ["@io_bazel_rules_webtesting//browsers:chromium-local"],
+    tags = ["local", "manual"],
+)
+
+closure_js_test(
+    name = "dom_webtest_test",
+    timeout = "short",
+    srcs = ["dom_test.js"],
+    deps = [
+        "@com_google_javascript_closure_library//closure/goog/dom",
+        "@com_google_javascript_closure_library//closure/goog/dom:tagname",
+        "@com_google_javascript_closure_library//closure/goog/html:safehtml",
+        "@com_google_javascript_closure_library//closure/goog/testing:asserts",
+        "@com_google_javascript_closure_library//closure/goog/testing:jsunit",
+    ],
+    browsers = ["@io_bazel_rules_webtesting//browsers:chromium-local"],
+    tags = ["local", "manual"],
+)
+
 # This test shows how to write tests to verify rendered output from phantomjs.
 # However, you shouln't do this because the output image depends on a lot of
 # external factors like operating system, GPU, ..., and therefore has a
@@ -159,3 +202,4 @@ closure_js_test(
 #     name = "darwin",
 #     values = {"cpu": "darwin"},
 # )
+

--- a/closure/testing/web_test_repositories.bzl
+++ b/closure/testing/web_test_repositories.bzl
@@ -1,0 +1,40 @@
+# TODO: Remove @bazel_gazelle and @io_bazel_rules_go when rules_webtesting is pinned to an
+# official release (>0.3.5).
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load(
+    "@io_bazel_rules_webtesting//web:go_repositories.bzl",
+    "go_repositories",
+    "go_internal_repositories",
+)
+load("@io_bazel_rules_webtesting//web:java_repositories.bzl", "java_repositories")
+load("@io_bazel_rules_webtesting//web:repositories.bzl", "web_test_repositories")
+load("@io_bazel_rules_webtesting//web/versioned:browsers-0.3.3.bzl", "browser_repositories")
+
+def setup_web_test_repositories(**kwargs):
+    """
+    Loading dependencies needed for web testing
+
+    Args:
+      **kwargs: Set which browser repositories to be loaded.
+    """
+
+    # TODO: Remove these 3 dependencies when rules_webtesting is pinned to an official
+    # release (>0.3.5).
+    go_rules_dependencies()
+    go_register_toolchains(version = "1.16.5")
+    gazelle_dependencies()
+
+    web_test_repositories()
+
+    browser_repositories(
+        **kwargs
+    )
+
+    # TODO: Remove these 2 dependencies when rules_webtesting is pinned to an official
+    # release (>0.3.5).
+    go_repositories()
+    go_internal_repositories()
+
+    java_repositories()
+

--- a/closure/testing/webdriver_test.bzl
+++ b/closure/testing/webdriver_test.bzl
@@ -1,0 +1,100 @@
+# Copyright 2022 The Closure Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Macro for running webtest with a test driver."""
+
+load("//closure:webfiles/web_library.bzl", "web_library")
+load("@io_bazel_rules_webtesting//web:web.bzl", "web_test_suite")
+
+def webdriver_test(
+        name,
+        browsers,
+        test_file_js,
+        tags = [],
+        visibility = None,
+        **kwargs):
+    """ Macro for running Closure JavaScript binary on browsers.
+
+    Args:
+        test_file_js: JavaScipt binary output from closure_js_binary
+        **kwargs: Additional arguments for web_test rules.
+
+    To run the test target, use `bazel test :<name>`.
+
+    To debug the test locally on the browser, add '_debug' to the name of your test. E.g.: `bazel run :<name>_debug`.
+    Open the URL printed in the console and click on the html link to the generated testsuite.
+    """
+
+    html = "gen_html_%s" % name
+    _gen_test_html(
+        name = html,
+        test_file_js = test_file_js,
+    )
+
+    path = "/"
+    html_webpath = "%s%s.html" % (path, html)
+
+    # set up a development web server that links to the test for debugging purposes.
+    web_library(
+        name = "%s_debug" % name,
+        srcs = [html, test_file_js],
+        path = path,
+    )
+
+    web_library(
+        name = "%s_test_runner" % name,
+        srcs = [html, test_file_js],
+        path = path,
+        server = Label("//java/io/bazel/rules/closure/testing:webdriver_test_bin"),
+    )
+
+    web_test_suite(
+        name = name,
+        data = [test_file_js, html],
+        test = ":%s_test_runner" % name,
+        args = [html_webpath],
+        browsers = browsers,
+        tags = tags + ["no-sandbox", "native"],
+        visibility = visibility,
+        **kwargs
+    )
+
+def _gen_test_html_impl(ctx):
+    """Implementation of the gen_test_html rule."""
+    ctx.actions.expand_template(
+        template = ctx.file._template,
+        output = ctx.outputs.html_file,
+        substitutions = {
+            "{{TEST_FILE_JS}}": ctx.attr.test_file_js,
+        },
+    )
+    runfiles = ctx.runfiles(files = [ctx.outputs.html_file], collect_default = True)
+    return [DefaultInfo(runfiles = runfiles)]
+
+# Used to generate default test.html file for running Closure-based JS tests.
+# The test_file_js argument specifies the name of the JS file containing tests,
+# typically created with closure_js_binary.
+# The output is created from gen_test_html.template file.
+_gen_test_html = rule(
+    implementation = _gen_test_html_impl,
+    attrs = {
+        "test_file_js": attr.string(mandatory = True),
+        "_template": attr.label(
+            default = Label("//closure/testing:gen_webtest_html.template"),
+            allow_single_file = True,
+        ),
+    },
+    outputs = {"html_file": "%{name}.html"},
+)
+

--- a/closure/webfiles/web_library.bzl
+++ b/closure/webfiles/web_library.bzl
@@ -76,6 +76,7 @@ def _web_library(ctx):
             longpath = long_path(ctx, src),
             webpath = webpath,
         ))
+
     webpaths += [depset(new_webpaths)]
     manifest = ctx.actions.declare_file("%s.pbtxt" % ctx.label.name)
     ctx.actions.write(
@@ -141,13 +142,13 @@ def _web_library(ctx):
         is_executable = True,
         output = ctx.outputs.executable,
         content = "#!/bin/sh\nexec %s %s \"$@\"" % (
-            ctx.executable._WebfilesServer.short_path,
+            ctx.executable.server.short_path,
             long_path(ctx, params_file),
         ),
     )
 
     transitive_runfiles = depset(
-        transitive = [ctx.attr._WebfilesServer.data_runfiles.files] +
+        transitive = [ctx.attr.server.data_runfiles.files] +
                      [dep.data_runfiles.files for dep in deps],
     )
 
@@ -223,7 +224,7 @@ web_library = rule(
             executable = True,
             cfg = "exec",
         ),
-        "_WebfilesServer": attr.label(
+        "server": attr.label(
             default = Label(
                 "//java/io/bazel/rules/closure/webfiles/server:WebfilesServer",
             ),

--- a/java/io/bazel/rules/closure/testing/BUILD
+++ b/java/io/bazel/rules/closure/testing/BUILD
@@ -1,0 +1,35 @@
+# Copyright 2022 The Closure Rules Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(
+    default_testonly = True,
+    default_visibility = ["//visibility:public"],
+)
+
+licenses(["notice"])  # Apache 2.0
+
+java_binary(
+    name = "webdriver_test_bin",
+    srcs = glob(["*.java"]),
+    main_class = "io.bazel.rules.closure.testing.TestRunner",
+    deps = [
+        "@org_seleniumhq_selenium_selenium_api",
+        "@org_seleniumhq_selenium_selenium_support",
+        "@org_seleniumhq_selenium_selenium_remote_driver",
+        "@io_bazel_rules_webtesting//java/com/google/testing/web:web",
+        "//java/io/bazel/rules/closure/webfiles/server",
+        "@com_google_guava",
+    ],
+    testonly = 1,
+)

--- a/java/io/bazel/rules/closure/testing/TestDriver.java
+++ b/java/io/bazel/rules/closure/testing/TestDriver.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022 The Closure Rules Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bazel.rules.closure.testing;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import com.google.testing.web.WebTest;
+import java.time.Duration;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.FluentWait;
+
+/** The test driver that triggers test running on the browser and collects test results. */
+public class TestDriver {
+
+  private static final Logger logger = Logger.getLogger(TestDriver.class.getName());
+  private static final long POLL_INTERVAL = 100;
+  private static final long TEST_TIMEOUT = 300;
+
+  private WebDriver driver;
+  private String htmlURL;
+  private boolean testFinishedSuccessfully;
+
+  public TestDriver(String htmlURL) {
+    this.driver = new WebTest().newWebDriverSession();
+    this.htmlURL = htmlURL;
+  }
+
+  public boolean run() {
+    driver.manage().timeouts().setScriptTimeout(TEST_TIMEOUT, SECONDS);
+    logger.info("WebDriver is running on: " + this.htmlURL);
+    driver.get(this.htmlURL);
+
+    try {
+      new FluentWait<>((JavascriptExecutor) driver)
+          .pollingEvery(Duration.ofMillis(POLL_INTERVAL))
+          .withTimeout(Duration.ofSeconds(TEST_TIMEOUT))
+          .until(
+              executor -> {
+                testFinishedSuccessfully =
+                    (boolean) executor.executeScript("return window.top.G_testRunner.isFinished()");
+                if (!testFinishedSuccessfully) {
+                  logger.log(Level.SEVERE, "G_testRunner has not finished successfully");
+                }
+                return true;
+              });
+    } catch (TimeoutException e) {
+      testFinishedSuccessfully = false;
+      logger.log(Level.SEVERE, String.format("Test timeout after %s seconds", TEST_TIMEOUT));
+    }
+
+    if (!testFinishedSuccessfully) {
+      return false;
+    }
+
+    String testReport =
+        ((JavascriptExecutor) driver)
+            .executeScript("return window.top.G_testRunner.getReport();")
+            .toString();
+    logger.info(testReport);
+
+    boolean allTestsPassed =
+        (boolean)
+            ((JavascriptExecutor) driver)
+                .executeScript("return window.top.G_testRunner.isSuccess();");
+
+    return allTestsPassed;
+  }
+
+  public void quit() {
+    driver.quit();
+  }
+}
+

--- a/java/io/bazel/rules/closure/testing/TestRunner.java
+++ b/java/io/bazel/rules/closure/testing/TestRunner.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 The Closure Rules Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.bazel.rules.closure.testing;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.net.HostAndPort;
+import io.bazel.rules.closure.webfiles.server.WebfilesServer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.openqa.selenium.net.PortProber;
+
+/**
+ * The test runner to run tests against browsers.
+ *
+ * <p>This program starts an HTTP server that serves runfiles. It uses a webdriver to load the
+ * generated test runner HTML file on the browser. Once the page is loaded, it polls the Closure
+ * Library repeatedly to check if the tests are finished, and logs results.
+ */
+class TestRunner {
+
+  private static final Logger logger = Logger.getLogger(TestRunner.class.getName());
+
+  public static void main(String args[]) throws Exception {
+    String serverConfig = args[0];
+    String htmlWebpath = args[1];
+    if (!htmlWebpath.startsWith("/")) {
+      htmlWebpath = "/" + htmlWebpath;
+    }
+
+    String bind = String.format("bind: \"localhost:%s\"", PortProber.findFreePort());
+
+    WebfilesServer server = null;
+    TestDriver driver = null;
+    boolean allTestsPassed = false;
+
+    try {
+      server = WebfilesServer.create(ImmutableList.of(serverConfig, bind));
+      HostAndPort hostAndPort = server.spawn();
+
+      driver = new TestDriver("http://" + hostAndPort + htmlWebpath);
+      allTestsPassed = driver.run();
+    } finally {
+      if (driver != null) {
+        driver.quit();
+      }
+      if (server != null) {
+        server.shutdown();
+      }
+    }
+
+    if (allTestsPassed) {
+      logger.info("All tests passed");
+      // TODO(#556): Remove this when the server can shutdown properly.
+      System.exit(0);
+    } else {
+      logger.log(
+          Level.SEVERE,
+          "Test(s) failed.\n"
+              + "TIPS: Debug your tests interactively on a browser using 'bazel run"
+              + " :<targetname>_debug'");
+      System.exit(1);
+    }
+  }
+}
+


### PR DESCRIPTION
Added the option to test with Selenium webdriver + rules_webtesting in `closure_js_test`.

* If `browsers` is specified, the tests will be run with Selenium webdriver/rules_webtesting.
* If `browsers` is not specified, there are no changes to the existing operation - the tests are run on phantomjs.

### Usage: 

Add `setup_web_test_repositories()` to WORKSPACE to load all repositories needed:
```
load("@io_bazel_rules_closure//closure:defs.bzl", "setup_web_test_repositories")
setup_web_test_repositories(
    chromium = True,
)
```

### Example:
```
closure_js_test(
    name = "simple_test",
    timeout = "short",
    srcs = ["simple_test.js"],
    deps = [
        "@com_google_javascript_closure_library//closure/goog/testing:asserts",
        "@com_google_javascript_closure_library//closure/goog/testing:jsunit",
    ],
    browsers = ["@io_bazel_rules_webtesting//browsers:chromium-local"],
)
```