### PR TITLE
Fix macOS arm64 select() support

### DIFF
--- a/closure/testing/test/BUILD
+++ b/closure/testing/test/BUILD
@@ -193,13 +193,7 @@ closure_js_test(
 #     name = "noto_fonts_render_as_expected",
 #     actual = "fontdemo-generated.png",
 #     golden = select({
-#         ":darwin": "fontdemo-darwin.png",
+#         "@platforms//os:macos": "fontdemo-darwin.png",
 #         "//conditions:default": "fontdemo.png",
 #     }),
 # )
-#
-# config_setting(
-#     name = "darwin",
-#     values = {"cpu": "darwin"},
-# )
-

--- a/third_party/llvm/llvm/tools/clang/BUILD
+++ b/third_party/llvm/llvm/tools/clang/BUILD
@@ -12,17 +12,11 @@ genrule(
         "TMP=$$(mktemp -d $${TMPDIR:-/tmp}/genrule.XXXXXXXXXX)",
         "cd $$TMP",
     ]) + " && " + select({
-        ":darwin": "tar xf $$IN */bin/clang-format",
+        "@platforms//os:macos": "tar xf $$IN */bin/clang-format",
         "//conditions:default": "tar xf $$IN --wildcards */bin/clang-format",
     }) + " && " + " && ".join([
         "mv */bin/clang-format $$OUT",
         "rm -rf $$TMP",
     ]),
     executable = True,
-)
-
-config_setting(
-    name = "darwin",
-    values = {"cpu": "darwin"},
-    visibility = ["//visibility:private"],
 )

--- a/third_party/phantomjs/BUILD
+++ b/third_party/phantomjs/BUILD
@@ -42,18 +42,12 @@ genrule(
         "TMP=$$(mktemp -d $${TMPDIR:-/tmp}/genrule.XXXXXXXXXX)",
         "cd $$TMP",
     ]) + select({
-        ":darwin": " && unzip -q $$IN && ",
+        "@platforms//os:macos": " && unzip -q $$IN && ",
         "//conditions:default": " && tar -xjf $$IN && ",
     }) + " && ".join([
         "mv */bin/phantomjs $$OUT",
         "rm -rf $$TMP",
     ]),
     executable = True,
-    visibility = ["//visibility:private"],
-)
-
-config_setting(
-    name = "darwin",
-    values = {"cpu": "darwin"},
     visibility = ["//visibility:private"],
 )


### PR DESCRIPTION
darwin is a CPU that means macOS x86_64 so these selects were invalid for arm64 macs. Also I'm hoping to remove this cpu to reduce confusion which would also break this.