### PR TITLE
Migrate usages of deprecated JavaInfo fields

### DIFF
--- a/closure/templates/closure_js_template_library.bzl
+++ b/closure/templates/closure_js_template_library.bzl
@@ -53,7 +53,7 @@ def _impl(ctx):
             inputs.append(f)
 
     plugin_transitive_deps = depset(
-        transitive = [m[SoyPluginInfo].generator.runtime.transitive_runtime_deps for m in ctx.attr.plugins],
+        transitive = [m[SoyPluginInfo].generator.runtime.transitive_runtime_jars for m in ctx.attr.plugins],
     ).to_list()
     inputs.extend(plugin_transitive_deps)
     plugin_classpath = [dep.path for dep in plugin_transitive_deps]


### PR DESCRIPTION

- transitive_runtime_deps was an alias for transitive_runtime_jars

The fields were deprecated in 2021, and are dropped in Bazel@HEAD

Fixes https://github.com/bazelbuild/rules_closure/issues/578

CC Greenteam @Wyverald 