### PR TITLE
Updates dom_test.js to not use goog.html.SafeHtml as goog.html.SafeHt…

### DIFF
--- a/closure/testing/test/BUILD
+++ b/closure/testing/test/BUILD
@@ -159,7 +159,6 @@ closure_js_test(
     deps = [
         "@com_google_javascript_closure_library//closure/goog/dom",
         "@com_google_javascript_closure_library//closure/goog/dom:tagname",
-        "@com_google_javascript_closure_library//closure/goog/html:safehtml",
         "@com_google_javascript_closure_library//closure/goog/testing:asserts",
         "@com_google_javascript_closure_library//closure/goog/testing:jsunit",
     ],

--- a/closure/testing/test/BUILD
+++ b/closure/testing/test/BUILD
@@ -90,7 +90,6 @@ closure_js_test(
     deps = [
         "@com_google_javascript_closure_library//closure/goog/dom",
         "@com_google_javascript_closure_library//closure/goog/dom:tagname",
-        "@com_google_javascript_closure_library//closure/goog/html:safehtml",
         "@com_google_javascript_closure_library//closure/goog/testing:asserts",
         "@com_google_javascript_closure_library//closure/goog/testing:jsunit",
     ],

--- a/closure/testing/test/dom_test.js
+++ b/closure/testing/test/dom_test.js
@@ -16,19 +16,15 @@ goog.setTestOnly();
 
 goog.require('goog.dom');
 goog.require('goog.dom.TagName');
-goog.require('goog.html.SafeHtml');
 goog.require('goog.testing.asserts');
 goog.require('goog.testing.jsunit');
 
 
 function setUp() {
-  goog.dom.appendChild(
-      goog.global.document.body,
-      goog.dom.safeHtmlToNode(
-          goog.html.SafeHtml.create(
-              goog.dom.TagName.DIV,
-              {'id': 'hello'},
-              'Hello World!')));
+  const div = goog.dom.createElement(goog.dom.TagName.DIV);
+  div.id = 'hello';
+  div.textContent = 'Hello World!';
+  goog.dom.appendChild(goog.global.document.body, div);
 }
 
 


### PR DESCRIPTION
…ml is deprecated in favor of safevalues, which can't be used in this case due to the OSS setup.