### PR TITLE
Fix incremental type checking for goog modules

### DIFF
--- a/closure/compiler/test/linting/BUILD
+++ b/closure/compiler/test/linting/BUILD
@@ -21,7 +21,10 @@ load("//closure:defs.bzl", "closure_js_library")
 
 closure_js_library(
     name = "love",
-    srcs = ["love.js"],
+    srcs = [
+        "love.js",
+        "somemodule.js",
+    ],
     internal_expect_failure = True,
 )
 
@@ -29,6 +32,12 @@ file_test(
     name = "methodMissingJsdoc_causesError",
     file = "love-stderr.txt",
     regexp = "JSC_MISSING_JSDOC",
+)
+
+file_test(
+    name = "checksGoogModule",
+    file = "love-stderr.txt",
+    regexp = "somemodule.js",
 )
 
 closure_js_library(
@@ -47,7 +56,10 @@ file_test(
 
 closure_js_library(
     name = "lenient_love",
-    srcs = ["love.js"],
+    srcs = [
+        "love.js",
+        "somemodule.js",
+    ],
     lenient = True,
 )
 
@@ -62,4 +74,17 @@ file_test(
     content = "",
     # This is a dummy file to trigger per library type check
     file = "lenient_love_typecheck",
+)
+
+closure_js_library(
+    name = "depends_lenient",
+    srcs = ["dummy.js"],
+    deps = [":lenient_love"],
+)
+
+file_test(
+    name = "depends_lenient_no_type_check_errors",
+    content = "",
+    # This is a dummy file to trigger per library type check
+    file = "depends_lenient_typecheck",
 )

--- a/closure/compiler/test/linting/somemodule.js
+++ b/closure/compiler/test/linting/somemodule.js
@@ -1,0 +1,23 @@
+// Copyright 2024 The Closure Rules Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+goog.module('somemodule');
+
+
+// I'm not documented!
+function foo(a, b) {
+  return a + b;
+}
+
+exports = foo;

--- a/java/com/google/javascript/jscomp/JsCheckerPassConfig.java
+++ b/java/com/google/javascript/jscomp/JsCheckerPassConfig.java
@@ -48,6 +48,7 @@ final class JsCheckerPassConfig extends PassConfig.PassConfigDelegate {
     this.checks.maybeAdd(closureRewriteClass());
     this.checks.maybeAdd(lateLintChecks());
     this.checks.maybeAdd(ijsGeneration());
+    this.checks.maybeAdd(whitespaceWrapGoogModules());
   }
 
   @Override
@@ -135,6 +136,13 @@ final class JsCheckerPassConfig extends PassConfig.PassConfigDelegate {
     return PassFactory.builder()
         .setName("ijsGeneration")
         .setInternalFactory((compiler) -> new ConvertToTypedInterface(compiler))
+        .build();
+  }
+
+  private PassFactory whitespaceWrapGoogModules() {
+    return PassFactory.builder()
+        .setName("whitespaceWrapGoogModules")
+        .setInternalFactory(WhitespaceWrapGoogModules::new)
         .build();
   }
 }

--- a/java/com/google/javascript/jscomp/JsCompilerRunner.java
+++ b/java/com/google/javascript/jscomp/JsCompilerRunner.java
@@ -18,6 +18,7 @@ package com.google.javascript.jscomp;
 
 import com.google.common.collect.Iterables;
 import com.google.javascript.jscomp.deps.ModuleLoader;
+import com.google.javascript.jscomp.ijs.CheckTypeSummaryWarningsGuard;
 import java.io.IOException;
 
 final class JsCompilerRunner extends CommandLineRunner {
@@ -56,6 +57,7 @@ final class JsCompilerRunner extends CommandLineRunner {
   protected CompilerOptions createOptions() {
     CompilerOptions options = super.createOptions();
     options.setExportTestFunctions(exportTestFunctions);
+    options.addWarningsGuard(new CheckTypeSummaryWarningsGuard(CheckLevel.OFF));
     options.addWarningsGuard(warnings);
     options.setModuleResolutionMode(ModuleLoader.ResolutionMode.NODE);
     return options;


### PR DESCRIPTION
 - Add CheckTypeSummaryWarningsGuard to ignore errors from ijs files.
 - Wrap modules in goog.modules for ijs files and sort them.
 - Add input delimiters to help with debugging.
