### PR TITLE
Add a null check to Long.equals

### DIFF
--- a/closure/library/long.js
+++ b/closure/library/long.js
@@ -225,6 +225,9 @@ class Long {
    * @return {boolean} Whether this Long equals the other.
    */
   equals(other) {
+    if (other == null) {
+      return false;
+    }
     // Compare low parts first as there is higher chance they are different.
     return (this.low_ == other.low_) && (this.high_ == other.high_);
   }


### PR DESCRIPTION
`Long.equals` accepts a nullable parameter, but will crash if you actually pass one. Instead we should always return null if `other` is null/undefined.

This is a backport of the internal version.