### PR TITLE
Move away from deprecated ScopedAliases pass constructor to new builder

### DIFF
--- a/java/com/google/javascript/jscomp/JsCheckerPassConfig.java
+++ b/java/com/google/javascript/jscomp/JsCheckerPassConfig.java
@@ -102,11 +102,7 @@ final class JsCheckerPassConfig extends PassConfig.PassConfigDelegate {
     return PassFactory.builder()
         .setName("scopedAliases")
         .setInternalFactory(
-            (compiler) ->
-                new ScopedAliases(
-                    compiler,
-                    /*preprocessorSymbolTable=*/ null,
-                    compiler.getOptions().getAliasTransformationHandler()))
+            (compiler) -> ScopedAliases.builder(compiler).build())
         .build();
   }
 


### PR DESCRIPTION
The builder doesn't require passing the empty preprocessorSymbolTable & getAliasTransformationHandler arguments; we're also planning to remove getAliasTransformationHandler  completely in Closure Compiler as it's unused.